### PR TITLE
Status only child reconciliation

### DIFF
--- a/reconcilers/reconcilers.go
+++ b/reconcilers/reconcilers.go
@@ -7,6 +7,7 @@ package reconcilers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"time"
@@ -299,6 +300,10 @@ func (r *SyncReconciler) sync(ctx context.Context, parent apis.Object) (ctrl.Res
 	return result, err
 }
 
+var (
+	OnlyReconcileChildStatus = errors.New("skip reconciler create/update/delete behavior for the child resource, while still reflecting the existing child's status on the parent")
+)
+
 // ChildReconciler is a sub reconciler that manages a single child resource for
 // a parent. The reconciler will ensure that exactly one child will match the
 // desired state by:
@@ -334,6 +339,10 @@ type ChildReconciler struct {
 
 	// DesiredChild returns the desired child object for the given parent
 	// object, or nil if the child should not exist.
+	//
+	// To skip reconciliation of the child resource while still reflecting an
+	// existing child's status on the parent, return OnlyReconcileChildStatus as
+	// an error.
 	//
 	// Expected function signature:
 	//     func(ctx context.Context, parent apis.Object) (apis.Object, error)
@@ -569,6 +578,9 @@ func (r *ChildReconciler) reconcile(ctx context.Context, parent apis.Object) (ap
 
 	desired, err := r.desiredChild(ctx, parent)
 	if err != nil {
+		if errors.Is(err, OnlyReconcileChildStatus) {
+			return actual, nil
+		}
 		return nil, err
 	}
 	if desired != nil {

--- a/reconcilers/reconcilers_test.go
+++ b/reconcilers/reconcilers_test.go
@@ -878,6 +878,23 @@ func TestChildReconciler(t *testing.T) {
 			},
 		},
 	}, {
+		Name:   "status only reconcile",
+		Parent: resource,
+		GivenObjects: []rtesting.Factory{
+			configMapGiven,
+		},
+		ExpectParent: resourceReady.
+			AddStatusField("foo", "bar"),
+		Metadata: map[string]interface{}{
+			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+				r := defaultChildReconciler(c)
+				r.DesiredChild = func(ctx context.Context, parent *rtesting.TestResource) (*corev1.ConfigMap, error) {
+					return nil, reconcilers.OnlyReconcileChildStatus
+				}
+				return r
+			},
+		},
+	}, {
 		Name: "sanitize child before logging",
 		Parent: resource.
 			AddField("foo", "bar"),


### PR DESCRIPTION
There are times when there is insufficient state to create/update a
child resource, but an existing resource should not be removed. The
existing child's status should still be reflected on the parent.

To skip reconciliation of the child resource while still reflecting an
existing child's status on the parent, return OnlyReconcileChildStatus
as an error from the DesiredChild method.

Signed-off-by: Scott Andrews <andrewssc@vmware.com>