### PR TITLE
Define reconciler Sequence as a SubReconciler

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ A [`Sequence`](https://pkg.go.dev/github.com/vmware-labs/reconciler-runtime/reco
 
 **Example:**
 
-A Sequence is commonly used in a ParentReconciler, but may be used anywhere a SubReconciler a accepted. 
+A Sequence is commonly used in a ParentReconciler, but may be used anywhere a SubReconciler is accepted. 
 
 ```go
 func FunctionReconciler(c reconcilers.Config) *reconcilers.ParentReconciler {

--- a/reconcilers/reconcilers.go
+++ b/reconcilers/reconcilers.go
@@ -72,7 +72,7 @@ type ParentReconciler struct {
 	Type runtime.Object
 
 	// Reconciler is called for each reconciler request with the parent
-	// resource being reconciled. Typically a Sequence is used to compose
+	// resource being reconciled. Typically, Reconciler is a Sequence of
 	// multiple SubReconcilers.
 	Reconciler SubReconciler
 

--- a/reconcilers/reconcilers_test.go
+++ b/reconcilers/reconcilers_test.go
@@ -49,14 +49,12 @@ func TestParentReconciler(t *testing.T) {
 		Name: "resource does not exist",
 		Key:  testKey,
 		Metadata: map[string]interface{}{
-			"SubReconcilers": func(t *testing.T, c reconcilers.Config) []reconcilers.SubReconciler {
-				return []reconcilers.SubReconciler{
-					&reconcilers.SyncReconciler{
-						Config: c,
-						Sync: func(ctx context.Context, parent *rtesting.TestResource) error {
-							t.Error("should not be called")
-							return nil
-						},
+			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+				return &reconcilers.SyncReconciler{
+					Config: c,
+					Sync: func(ctx context.Context, parent *rtesting.TestResource) error {
+						t.Error("should not be called")
+						return nil
 					},
 				}
 			},
@@ -70,14 +68,12 @@ func TestParentReconciler(t *testing.T) {
 			}),
 		},
 		Metadata: map[string]interface{}{
-			"SubReconcilers": func(t *testing.T, c reconcilers.Config) []reconcilers.SubReconciler {
-				return []reconcilers.SubReconciler{
-					&reconcilers.SyncReconciler{
-						Config: c,
-						Sync: func(ctx context.Context, parent *rtesting.TestResource) error {
-							t.Error("should not be called")
-							return nil
-						},
+			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+				return &reconcilers.SyncReconciler{
+					Config: c,
+					Sync: func(ctx context.Context, parent *rtesting.TestResource) error {
+						t.Error("should not be called")
+						return nil
 					},
 				}
 			},
@@ -94,14 +90,12 @@ func TestParentReconciler(t *testing.T) {
 			rtesting.InduceFailure("get", "TestResource"),
 		},
 		Metadata: map[string]interface{}{
-			"SubReconcilers": func(t *testing.T, c reconcilers.Config) []reconcilers.SubReconciler {
-				return []reconcilers.SubReconciler{
-					&reconcilers.SyncReconciler{
-						Config: c,
-						Sync: func(ctx context.Context, parent *rtesting.TestResource) error {
-							t.Error("should not be called")
-							return nil
-						},
+			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+				return &reconcilers.SyncReconciler{
+					Config: c,
+					Sync: func(ctx context.Context, parent *rtesting.TestResource) error {
+						t.Error("should not be called")
+						return nil
 					},
 				}
 			},
@@ -114,16 +108,14 @@ func TestParentReconciler(t *testing.T) {
 			resource,
 		},
 		Metadata: map[string]interface{}{
-			"SubReconcilers": func(t *testing.T, c reconcilers.Config) []reconcilers.SubReconciler {
-				return []reconcilers.SubReconciler{
-					&reconcilers.SyncReconciler{
-						Config: c,
-						Sync: func(ctx context.Context, parent *rtesting.TestResource) error {
-							if expected, actual := "ran", parent.Spec.Fields["Defaulter"]; expected != actual {
-								t.Errorf("unexpected default value, actually = %v, expected = %v", expected, actual)
-							}
-							return nil
-						},
+			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+				return &reconcilers.SyncReconciler{
+					Config: c,
+					Sync: func(ctx context.Context, parent *rtesting.TestResource) error {
+						if expected, actual := "ran", parent.Spec.Fields["Defaulter"]; expected != actual {
+							t.Errorf("unexpected default value, actually = %v, expected = %v", expected, actual)
+						}
+						return nil
 					},
 				}
 			},
@@ -135,19 +127,17 @@ func TestParentReconciler(t *testing.T) {
 			resource.StatusConditions(),
 		},
 		Metadata: map[string]interface{}{
-			"SubReconcilers": func(t *testing.T, c reconcilers.Config) []reconcilers.SubReconciler {
-				return []reconcilers.SubReconciler{
-					&reconcilers.SyncReconciler{
-						Config: c,
-						Sync: func(ctx context.Context, parent *rtesting.TestResource) error {
-							expected := apis.Conditions{
-								{Type: apis.ConditionReady, Status: corev1.ConditionUnknown},
-							}
-							if diff := cmp.Diff(expected, parent.Status.Conditions, rtesting.IgnoreLastTransitionTime); diff != "" {
-								t.Errorf("Unexpected condition (-expected, +actual): %s", diff)
-							}
-							return nil
-						},
+			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+				return &reconcilers.SyncReconciler{
+					Config: c,
+					Sync: func(ctx context.Context, parent *rtesting.TestResource) error {
+						expected := apis.Conditions{
+							{Type: apis.ConditionReady, Status: corev1.ConditionUnknown},
+						}
+						if diff := cmp.Diff(expected, parent.Status.Conditions, rtesting.IgnoreLastTransitionTime); diff != "" {
+							t.Errorf("Unexpected condition (-expected, +actual): %s", diff)
+						}
+						return nil
 					},
 				}
 			},
@@ -166,8 +156,8 @@ func TestParentReconciler(t *testing.T) {
 			resource,
 		},
 		Metadata: map[string]interface{}{
-			"SubReconcilers": func(t *testing.T, c reconcilers.Config) []reconcilers.SubReconciler {
-				return []reconcilers.SubReconciler{&reconcilers.SyncReconciler{
+			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+				return &reconcilers.SyncReconciler{
 					Config: c,
 					Sync: func(ctx context.Context, parent *rtesting.TestResource) error {
 						if parent.Status.Fields == nil {
@@ -176,7 +166,6 @@ func TestParentReconciler(t *testing.T) {
 						parent.Status.Fields["Reconciler"] = "ran"
 						return nil
 					},
-				},
 				}
 			},
 		},
@@ -194,275 +183,16 @@ func TestParentReconciler(t *testing.T) {
 			resource,
 		},
 		Metadata: map[string]interface{}{
-			"SubReconcilers": func(t *testing.T, c reconcilers.Config) []reconcilers.SubReconciler {
-				return []reconcilers.SubReconciler{
-					&reconcilers.SyncReconciler{
-						Config: c,
-						Sync: func(ctx context.Context, parent *rtesting.TestResource) error {
-							return fmt.Errorf("reconciler error")
-						},
+			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+				return &reconcilers.SyncReconciler{
+					Config: c,
+					Sync: func(ctx context.Context, parent *rtesting.TestResource) error {
+						return fmt.Errorf("reconciler error")
 					},
 				}
 			},
 		},
 		ShouldErr: true,
-	}, {
-		Name: "preserves result, Requeue",
-		Key:  testKey,
-		GivenObjects: []rtesting.Factory{
-			resource,
-		},
-		Metadata: map[string]interface{}{
-			"SubReconcilers": func(t *testing.T, c reconcilers.Config) []reconcilers.SubReconciler {
-				return []reconcilers.SubReconciler{&reconcilers.SyncReconciler{
-					Config: c,
-					Sync: func(ctx context.Context, parent *rtesting.TestResource) (ctrl.Result, error) {
-						return ctrl.Result{Requeue: true}, nil
-					},
-				},
-				}
-			},
-		},
-		ExpectedResult: ctrl.Result{Requeue: true},
-	}, {
-		Name: "preserves result, RequeueAfter",
-		Key:  testKey,
-		GivenObjects: []rtesting.Factory{
-			resource,
-		},
-		Metadata: map[string]interface{}{
-			"SubReconcilers": func(t *testing.T, c reconcilers.Config) []reconcilers.SubReconciler {
-				return []reconcilers.SubReconciler{
-					&reconcilers.SyncReconciler{
-						Config: c,
-						Sync: func(ctx context.Context, parent *rtesting.TestResource) (ctrl.Result, error) {
-							return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
-						},
-					},
-				}
-			},
-		},
-		ExpectedResult: ctrl.Result{RequeueAfter: 1 * time.Minute},
-	}, {
-		Name: "ignores result on err",
-		Key:  testKey,
-		GivenObjects: []rtesting.Factory{
-			resource,
-		},
-		Metadata: map[string]interface{}{
-			"SubReconcilers": func(t *testing.T, c reconcilers.Config) []reconcilers.SubReconciler {
-				return []reconcilers.SubReconciler{
-					&reconcilers.SyncReconciler{
-						Config: c,
-						Sync: func(ctx context.Context, parent *rtesting.TestResource) (ctrl.Result, error) {
-							return ctrl.Result{Requeue: true}, fmt.Errorf("test error")
-						},
-					},
-				}
-			},
-		},
-		ExpectedResult: ctrl.Result{},
-		ShouldErr:      true,
-	}, {
-		Name: "Requeue + empty => Requeue",
-		Key:  testKey,
-		GivenObjects: []rtesting.Factory{
-			resource,
-		},
-		Metadata: map[string]interface{}{
-			"SubReconcilers": func(t *testing.T, c reconcilers.Config) []reconcilers.SubReconciler {
-				return []reconcilers.SubReconciler{
-					&reconcilers.SyncReconciler{
-						Config: c,
-						Sync: func(ctx context.Context, parent *rtesting.TestResource) (ctrl.Result, error) {
-							return ctrl.Result{Requeue: true}, nil
-						},
-					},
-					&reconcilers.SyncReconciler{
-						Config: c,
-						Sync: func(ctx context.Context, parent *rtesting.TestResource) (ctrl.Result, error) {
-							return ctrl.Result{}, nil
-						},
-					},
-				}
-			},
-		},
-		ExpectedResult: ctrl.Result{Requeue: true},
-	}, {
-		Name: "empty + Requeue => Requeue",
-		Key:  testKey,
-		GivenObjects: []rtesting.Factory{
-			resource,
-		},
-		Metadata: map[string]interface{}{
-			"SubReconcilers": func(t *testing.T, c reconcilers.Config) []reconcilers.SubReconciler {
-				return []reconcilers.SubReconciler{
-					&reconcilers.SyncReconciler{
-						Config: c,
-						Sync: func(ctx context.Context, parent *rtesting.TestResource) (ctrl.Result, error) {
-							return ctrl.Result{}, nil
-						},
-					},
-					&reconcilers.SyncReconciler{
-						Config: c,
-						Sync: func(ctx context.Context, parent *rtesting.TestResource) (ctrl.Result, error) {
-							return ctrl.Result{Requeue: true}, nil
-						},
-					},
-				}
-			},
-		},
-		ExpectedResult: ctrl.Result{Requeue: true},
-	}, {
-		Name: "RequeueAfter + empty => RequeueAfter",
-		Key:  testKey,
-		GivenObjects: []rtesting.Factory{
-			resource,
-		},
-		Metadata: map[string]interface{}{
-			"SubReconcilers": func(t *testing.T, c reconcilers.Config) []reconcilers.SubReconciler {
-				return []reconcilers.SubReconciler{
-					&reconcilers.SyncReconciler{
-						Config: c,
-						Sync: func(ctx context.Context, parent *rtesting.TestResource) (ctrl.Result, error) {
-							return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
-						},
-					},
-					&reconcilers.SyncReconciler{
-						Config: c,
-						Sync: func(ctx context.Context, parent *rtesting.TestResource) (ctrl.Result, error) {
-							return ctrl.Result{}, nil
-						},
-					},
-				}
-			},
-		},
-		ExpectedResult: ctrl.Result{RequeueAfter: 1 * time.Minute},
-	}, {
-		Name: "empty + RequeueAfter => RequeueAfter",
-		Key:  testKey,
-		GivenObjects: []rtesting.Factory{
-			resource,
-		},
-		Metadata: map[string]interface{}{
-			"SubReconcilers": func(t *testing.T, c reconcilers.Config) []reconcilers.SubReconciler {
-				return []reconcilers.SubReconciler{
-					&reconcilers.SyncReconciler{
-						Config: c,
-						Sync: func(ctx context.Context, parent *rtesting.TestResource) (ctrl.Result, error) {
-							return ctrl.Result{}, nil
-						},
-					},
-					&reconcilers.SyncReconciler{
-						Config: c,
-						Sync: func(ctx context.Context, parent *rtesting.TestResource) (ctrl.Result, error) {
-							return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
-						},
-					},
-				}
-			},
-		},
-		ExpectedResult: ctrl.Result{RequeueAfter: 1 * time.Minute},
-	}, {
-		Name: "RequeueAfter + Requeue => RequeueAfter",
-		Key:  testKey,
-		GivenObjects: []rtesting.Factory{
-			resource,
-		},
-		Metadata: map[string]interface{}{
-			"SubReconcilers": func(t *testing.T, c reconcilers.Config) []reconcilers.SubReconciler {
-				return []reconcilers.SubReconciler{
-					&reconcilers.SyncReconciler{
-						Config: c,
-						Sync: func(ctx context.Context, parent *rtesting.TestResource) (ctrl.Result, error) {
-							return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
-						},
-					},
-					&reconcilers.SyncReconciler{
-						Config: c,
-						Sync: func(ctx context.Context, parent *rtesting.TestResource) (ctrl.Result, error) {
-							return ctrl.Result{Requeue: true}, nil
-						},
-					},
-				}
-			},
-		},
-		ExpectedResult: ctrl.Result{RequeueAfter: 1 * time.Minute},
-	}, {
-		Name: "Requeue + RequeueAfter => RequeueAfter",
-		Key:  testKey,
-		GivenObjects: []rtesting.Factory{
-			resource,
-		},
-		Metadata: map[string]interface{}{
-			"SubReconcilers": func(t *testing.T, c reconcilers.Config) []reconcilers.SubReconciler {
-				return []reconcilers.SubReconciler{
-					&reconcilers.SyncReconciler{
-						Config: c,
-						Sync: func(ctx context.Context, parent *rtesting.TestResource) (ctrl.Result, error) {
-							return ctrl.Result{Requeue: true}, nil
-						},
-					},
-					&reconcilers.SyncReconciler{
-						Config: c,
-						Sync: func(ctx context.Context, parent *rtesting.TestResource) (ctrl.Result, error) {
-							return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
-						},
-					},
-				}
-			},
-		},
-		ExpectedResult: ctrl.Result{RequeueAfter: 1 * time.Minute},
-	}, {
-		Name: "RequeueAfter(1m) + RequeueAfter(2m) => RequeueAfter(1m)",
-		Key:  testKey,
-		GivenObjects: []rtesting.Factory{
-			resource,
-		},
-		Metadata: map[string]interface{}{
-			"SubReconcilers": func(t *testing.T, c reconcilers.Config) []reconcilers.SubReconciler {
-				return []reconcilers.SubReconciler{
-					&reconcilers.SyncReconciler{
-						Config: c,
-						Sync: func(ctx context.Context, parent *rtesting.TestResource) (ctrl.Result, error) {
-							return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
-						},
-					},
-					&reconcilers.SyncReconciler{
-						Config: c,
-						Sync: func(ctx context.Context, parent *rtesting.TestResource) (ctrl.Result, error) {
-							return ctrl.Result{RequeueAfter: 2 * time.Minute}, nil
-						},
-					},
-				}
-			},
-		},
-		ExpectedResult: ctrl.Result{RequeueAfter: 1 * time.Minute},
-	}, {
-		Name: "RequeueAfter(2m) + RequeueAfter(1m) => RequeueAfter(1m)",
-		Key:  testKey,
-		GivenObjects: []rtesting.Factory{
-			resource,
-		},
-		Metadata: map[string]interface{}{
-			"SubReconcilers": func(t *testing.T, c reconcilers.Config) []reconcilers.SubReconciler {
-				return []reconcilers.SubReconciler{
-					&reconcilers.SyncReconciler{
-						Config: c,
-						Sync: func(ctx context.Context, parent *rtesting.TestResource) (ctrl.Result, error) {
-							return ctrl.Result{RequeueAfter: 2 * time.Minute}, nil
-						},
-					},
-					&reconcilers.SyncReconciler{
-						Config: c,
-						Sync: func(ctx context.Context, parent *rtesting.TestResource) (ctrl.Result, error) {
-							return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
-						},
-					},
-				}
-			},
-		},
-		ExpectedResult: ctrl.Result{RequeueAfter: 1 * time.Minute},
 	}, {
 		Name: "status update failed",
 		Key:  testKey,
@@ -475,17 +205,15 @@ func TestParentReconciler(t *testing.T) {
 			}),
 		},
 		Metadata: map[string]interface{}{
-			"SubReconcilers": func(t *testing.T, c reconcilers.Config) []reconcilers.SubReconciler {
-				return []reconcilers.SubReconciler{
-					&reconcilers.SyncReconciler{
-						Config: c,
-						Sync: func(ctx context.Context, parent *rtesting.TestResource) error {
-							if parent.Status.Fields == nil {
-								parent.Status.Fields = map[string]string{}
-							}
-							parent.Status.Fields["Reconciler"] = "ran"
-							return nil
-						},
+			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+				return &reconcilers.SyncReconciler{
+					Config: c,
+					Sync: func(ctx context.Context, parent *rtesting.TestResource) error {
+						if parent.Status.Fields == nil {
+							parent.Status.Fields = map[string]string{}
+						}
+						parent.Status.Fields["Reconciler"] = "ran"
+						return nil
 					},
 				}
 			},
@@ -505,16 +233,14 @@ func TestParentReconciler(t *testing.T) {
 			resource,
 		},
 		Metadata: map[string]interface{}{
-			"SubReconcilers": func(t *testing.T, c reconcilers.Config) []reconcilers.SubReconciler {
-				return []reconcilers.SubReconciler{
-					&reconcilers.SyncReconciler{
-						Config: c,
-						Sync: func(ctx context.Context, parent *rtesting.TestResource) error {
-							var key reconcilers.StashKey = "foo"
-							// StashValue will panic if the context is not setup correctly
-							reconcilers.StashValue(ctx, key, "bar")
-							return nil
-						},
+			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+				return &reconcilers.SyncReconciler{
+					Config: c,
+					Sync: func(ctx context.Context, parent *rtesting.TestResource) error {
+						var key reconcilers.StashKey = "foo"
+						// StashValue will panic if the context is not setup correctly
+						reconcilers.StashValue(ctx, key, "bar")
+						return nil
 					},
 				}
 			},
@@ -523,9 +249,9 @@ func TestParentReconciler(t *testing.T) {
 
 	rts.Test(t, scheme, func(t *testing.T, rtc *rtesting.ReconcilerTestCase, c reconcilers.Config) reconcile.Reconciler {
 		return &reconcilers.ParentReconciler{
-			Type:           &rtesting.TestResource{},
-			SubReconcilers: rtc.Metadata["SubReconcilers"].(func(*testing.T, reconcilers.Config) []reconcilers.SubReconciler)(t, c),
-			Config:         c,
+			Type:       &rtesting.TestResource{},
+			Reconciler: rtc.Metadata["SubReconciler"].(func(*testing.T, reconcilers.Config) reconcilers.SubReconciler)(t, c),
+			Config:     c,
 		}
 	})
 }
@@ -1054,6 +780,304 @@ func TestChildReconciler(t *testing.T) {
 			},
 		},
 		ShouldErr: true,
+	}}
+
+	rts.Test(t, scheme, func(t *testing.T, rtc *rtesting.SubReconcilerTestCase, c reconcilers.Config) reconcilers.SubReconciler {
+		return rtc.Metadata["SubReconciler"].(func(*testing.T, reconcilers.Config) reconcilers.SubReconciler)(t, c)
+	})
+}
+
+func TestSequence(t *testing.T) {
+	testNamespace := "test-namespace"
+	testName := "test-resource"
+
+	scheme := runtime.NewScheme()
+	_ = rtesting.AddToScheme(scheme)
+
+	resource := factories.TestResource().
+		NamespaceName(testNamespace, testName).
+		ObjectMeta(func(om factories.ObjectMeta) {
+			om.Created(1)
+		}).
+		StatusConditions(
+			factories.Condition().Type(apis.ConditionReady).Unknown(),
+		)
+
+	rts := rtesting.SubReconcilerTestSuite{{
+		Name:   "sub reconciler erred",
+		Parent: resource,
+		GivenObjects: []rtesting.Factory{
+			resource,
+		},
+		Metadata: map[string]interface{}{
+			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+				return reconcilers.Sequence{
+					&reconcilers.SyncReconciler{
+						Config: c,
+						Sync: func(ctx context.Context, parent *rtesting.TestResource) error {
+							return fmt.Errorf("reconciler error")
+						},
+					},
+				}
+			},
+		},
+		ShouldErr: true,
+	}, {
+		Name:   "preserves result, Requeue",
+		Parent: resource,
+		GivenObjects: []rtesting.Factory{
+			resource,
+		},
+		Metadata: map[string]interface{}{
+			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+				return &reconcilers.SyncReconciler{
+					Config: c,
+					Sync: func(ctx context.Context, parent *rtesting.TestResource) (ctrl.Result, error) {
+						return ctrl.Result{Requeue: true}, nil
+					},
+				}
+			},
+		},
+		ExpectedResult: ctrl.Result{Requeue: true},
+	}, {
+		Name:   "preserves result, RequeueAfter",
+		Parent: resource,
+		GivenObjects: []rtesting.Factory{
+			resource,
+		},
+		Metadata: map[string]interface{}{
+			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+				return reconcilers.Sequence{
+					&reconcilers.SyncReconciler{
+						Config: c,
+						Sync: func(ctx context.Context, parent *rtesting.TestResource) (ctrl.Result, error) {
+							return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
+						},
+					},
+				}
+			},
+		},
+		ExpectedResult: ctrl.Result{RequeueAfter: 1 * time.Minute},
+	}, {
+		Name:   "ignores result on err",
+		Parent: resource,
+		GivenObjects: []rtesting.Factory{
+			resource,
+		},
+		Metadata: map[string]interface{}{
+			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+				return reconcilers.Sequence{
+					&reconcilers.SyncReconciler{
+						Config: c,
+						Sync: func(ctx context.Context, parent *rtesting.TestResource) (ctrl.Result, error) {
+							return ctrl.Result{Requeue: true}, fmt.Errorf("test error")
+						},
+					},
+				}
+			},
+		},
+		ExpectedResult: ctrl.Result{},
+		ShouldErr:      true,
+	}, {
+		Name:   "Requeue + empty => Requeue",
+		Parent: resource,
+		GivenObjects: []rtesting.Factory{
+			resource,
+		},
+		Metadata: map[string]interface{}{
+			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+				return reconcilers.Sequence{
+					&reconcilers.SyncReconciler{
+						Config: c,
+						Sync: func(ctx context.Context, parent *rtesting.TestResource) (ctrl.Result, error) {
+							return ctrl.Result{Requeue: true}, nil
+						},
+					},
+					&reconcilers.SyncReconciler{
+						Config: c,
+						Sync: func(ctx context.Context, parent *rtesting.TestResource) (ctrl.Result, error) {
+							return ctrl.Result{}, nil
+						},
+					},
+				}
+			},
+		},
+		ExpectedResult: ctrl.Result{Requeue: true},
+	}, {
+		Name:   "empty + Requeue => Requeue",
+		Parent: resource,
+		GivenObjects: []rtesting.Factory{
+			resource,
+		},
+		Metadata: map[string]interface{}{
+			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+				return reconcilers.Sequence{
+					&reconcilers.SyncReconciler{
+						Config: c,
+						Sync: func(ctx context.Context, parent *rtesting.TestResource) (ctrl.Result, error) {
+							return ctrl.Result{}, nil
+						},
+					},
+					&reconcilers.SyncReconciler{
+						Config: c,
+						Sync: func(ctx context.Context, parent *rtesting.TestResource) (ctrl.Result, error) {
+							return ctrl.Result{Requeue: true}, nil
+						},
+					},
+				}
+			},
+		},
+		ExpectedResult: ctrl.Result{Requeue: true},
+	}, {
+		Name:   "RequeueAfter + empty => RequeueAfter",
+		Parent: resource,
+		GivenObjects: []rtesting.Factory{
+			resource,
+		},
+		Metadata: map[string]interface{}{
+			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+				return reconcilers.Sequence{
+					&reconcilers.SyncReconciler{
+						Config: c,
+						Sync: func(ctx context.Context, parent *rtesting.TestResource) (ctrl.Result, error) {
+							return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
+						},
+					},
+					&reconcilers.SyncReconciler{
+						Config: c,
+						Sync: func(ctx context.Context, parent *rtesting.TestResource) (ctrl.Result, error) {
+							return ctrl.Result{}, nil
+						},
+					},
+				}
+			},
+		},
+		ExpectedResult: ctrl.Result{RequeueAfter: 1 * time.Minute},
+	}, {
+		Name:   "empty + RequeueAfter => RequeueAfter",
+		Parent: resource,
+		GivenObjects: []rtesting.Factory{
+			resource,
+		},
+		Metadata: map[string]interface{}{
+			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+				return reconcilers.Sequence{
+					&reconcilers.SyncReconciler{
+						Config: c,
+						Sync: func(ctx context.Context, parent *rtesting.TestResource) (ctrl.Result, error) {
+							return ctrl.Result{}, nil
+						},
+					},
+					&reconcilers.SyncReconciler{
+						Config: c,
+						Sync: func(ctx context.Context, parent *rtesting.TestResource) (ctrl.Result, error) {
+							return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
+						},
+					},
+				}
+			},
+		},
+		ExpectedResult: ctrl.Result{RequeueAfter: 1 * time.Minute},
+	}, {
+		Name:   "RequeueAfter + Requeue => RequeueAfter",
+		Parent: resource,
+		GivenObjects: []rtesting.Factory{
+			resource,
+		},
+		Metadata: map[string]interface{}{
+			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+				return reconcilers.Sequence{
+					&reconcilers.SyncReconciler{
+						Config: c,
+						Sync: func(ctx context.Context, parent *rtesting.TestResource) (ctrl.Result, error) {
+							return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
+						},
+					},
+					&reconcilers.SyncReconciler{
+						Config: c,
+						Sync: func(ctx context.Context, parent *rtesting.TestResource) (ctrl.Result, error) {
+							return ctrl.Result{Requeue: true}, nil
+						},
+					},
+				}
+			},
+		},
+		ExpectedResult: ctrl.Result{RequeueAfter: 1 * time.Minute},
+	}, {
+		Name:   "Requeue + RequeueAfter => RequeueAfter",
+		Parent: resource,
+		GivenObjects: []rtesting.Factory{
+			resource,
+		},
+		Metadata: map[string]interface{}{
+			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+				return reconcilers.Sequence{
+					&reconcilers.SyncReconciler{
+						Config: c,
+						Sync: func(ctx context.Context, parent *rtesting.TestResource) (ctrl.Result, error) {
+							return ctrl.Result{Requeue: true}, nil
+						},
+					},
+					&reconcilers.SyncReconciler{
+						Config: c,
+						Sync: func(ctx context.Context, parent *rtesting.TestResource) (ctrl.Result, error) {
+							return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
+						},
+					},
+				}
+			},
+		},
+		ExpectedResult: ctrl.Result{RequeueAfter: 1 * time.Minute},
+	}, {
+		Name:   "RequeueAfter(1m) + RequeueAfter(2m) => RequeueAfter(1m)",
+		Parent: resource,
+		GivenObjects: []rtesting.Factory{
+			resource,
+		},
+		Metadata: map[string]interface{}{
+			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+				return reconcilers.Sequence{
+					&reconcilers.SyncReconciler{
+						Config: c,
+						Sync: func(ctx context.Context, parent *rtesting.TestResource) (ctrl.Result, error) {
+							return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
+						},
+					},
+					&reconcilers.SyncReconciler{
+						Config: c,
+						Sync: func(ctx context.Context, parent *rtesting.TestResource) (ctrl.Result, error) {
+							return ctrl.Result{RequeueAfter: 2 * time.Minute}, nil
+						},
+					},
+				}
+			},
+		},
+		ExpectedResult: ctrl.Result{RequeueAfter: 1 * time.Minute},
+	}, {
+		Name:   "RequeueAfter(2m) + RequeueAfter(1m) => RequeueAfter(1m)",
+		Parent: resource,
+		GivenObjects: []rtesting.Factory{
+			resource,
+		},
+		Metadata: map[string]interface{}{
+			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+				return reconcilers.Sequence{
+					&reconcilers.SyncReconciler{
+						Config: c,
+						Sync: func(ctx context.Context, parent *rtesting.TestResource) (ctrl.Result, error) {
+							return ctrl.Result{RequeueAfter: 2 * time.Minute}, nil
+						},
+					},
+					&reconcilers.SyncReconciler{
+						Config: c,
+						Sync: func(ctx context.Context, parent *rtesting.TestResource) (ctrl.Result, error) {
+							return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
+						},
+					},
+				}
+			},
+		},
+		ExpectedResult: ctrl.Result{RequeueAfter: 1 * time.Minute},
 	}}
 
 	rts.Test(t, scheme, func(t *testing.T, rtc *rtesting.SubReconcilerTestCase, c reconcilers.Config) reconcilers.SubReconciler {

--- a/testing/subreconciler.go
+++ b/testing/subreconciler.go
@@ -171,7 +171,7 @@ func (tc *SubReconcilerTestCase) Test(t *testing.T, scheme *runtime.Scheme, fact
 	}
 	if err == nil {
 		// result is only significant if there wasn't an error
-		if diff := cmp.Diff(tc.ExpectedResult, result); diff != "" {
+		if diff := cmp.Diff(normalizeResult(tc.ExpectedResult), normalizeResult(result)); diff != "" {
 			t.Errorf("Unexpected result (-expected, +actual): %s", diff)
 		}
 	}


### PR DESCRIPTION
A Sequence composes multiple SubReconcilers as a single SubReconciler.
Each sub reconciler is called in turn, aggregating the result of each
sub reconciler. A reconciler returning an error will interrupt the
sequence.

The sequence was abstracted from the ParentReconciler, which now accepts
a SubReconciler instead of an slice of SubReconcilers.

**Breaking changes:**

`ParentReconciler#SubReconcilers []SubReconciler` is now
`ParentReconciler#Reconciler SubReconciler`.

Before:

```go
&reconcilers.ParentReconciler{
	Type: &buildv1alpha1.Function{},
	SubReconcilers: []reconcilers.SubReconcilers{
		FunctionTargetImageReconciler(c),
		FunctionChildImageReconciler(c),
	},

	Config: c,
}
```

After:

```go
&reconcilers.ParentReconciler{
	Type: &buildv1alpha1.Function{},
	Reconciler: reconcilers.Sequence{
		FunctionTargetImageReconciler(c),
		FunctionChildImageReconciler(c),
	},

	Config: c,
}
```

Signed-off-by: Scott Andrews <andrewssc@vmware.com>