### PR TITLE
Reflect mutations from cast parent back to parent

### DIFF
--- a/reconcilers/reconcilers.go
+++ b/reconcilers/reconcilers.go
@@ -841,14 +841,22 @@ func (r *CastParent) Reconcile(ctx context.Context, parent apis.Object) (ctrl.Re
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	castOriginal := castParent.DeepCopyObject()
+	castOriginal := castParent.DeepCopyObject().(apis.Object)
 	result, err := r.Reconciler.Reconcile(ctx, castParent)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 	if !equality.Semantic.DeepEqual(castParent, castOriginal) {
-		// TODO apply diff to parent resource, until then err
-		return ctrl.Result{}, fmt.Errorf("cast parent resource mutated")
+		// patch the parent object with the updated duck values
+		patch, err := NewPatch(castOriginal, castParent)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		err = patch.Apply(parent)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+
 	}
 	return result, nil
 }


### PR DESCRIPTION
The CastParent higher order reconciler is useful for operating on a
fragment of a resource with a compatible structure represented by a duck
type. Previously, this mapping was read-only, with mutations of the cast
parent resulting in an error. Now changes to the cast parent are
reflected back to the original parent type.

Just like the cast resource will only contain fields defined by both the
parent type and the cast type, mutation on portions of the cast resource
that are not available on the parent type are dropped.

Signed-off-by: Scott Andrews <andrewssc@vmware.com>