### PR TITLE
Remove scheme from config

### DIFF
--- a/reconcilers/reconcilers_test.go
+++ b/reconcilers/reconcilers_test.go
@@ -767,20 +767,6 @@ func TestChildReconciler(t *testing.T) {
 			},
 		},
 		ShouldErr: true,
-	}, {
-		Name: "error empty scheme",
-		Parent: resource.
-			AddField("foo", "bar"),
-		GivenObjects: []rtesting.Factory{},
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				r := defaultChildReconciler(c)
-				scheme := runtime.NewScheme()
-				r.Config.Scheme = scheme
-				return r
-			},
-		},
-		ShouldErr: true,
 	}}
 
 	rts.Test(t, scheme, func(t *testing.T, rtc *rtesting.SubReconcilerTestCase, c reconcilers.Config) reconcilers.SubReconciler {

--- a/testing/reconciler.go
+++ b/testing/reconciler.go
@@ -126,7 +126,6 @@ func (tc *ReconcilerTestCase) Test(t *testing.T, scheme *runtime.Scheme, factory
 		APIReader: apiReader,
 		Tracker:   tracker,
 		Recorder:  recorder,
-		Scheme:    scheme,
 		Log:       log,
 	})
 

--- a/testing/subreconciler.go
+++ b/testing/subreconciler.go
@@ -125,7 +125,6 @@ func (tc *SubReconcilerTestCase) Test(t *testing.T, scheme *runtime.Scheme, fact
 		APIReader: apiReader,
 		Tracker:   tracker,
 		Recorder:  recorder,
-		Scheme:    scheme,
 		Log:       log,
 	})
 


### PR DESCRIPTION
The client has a method to lookup the current scheme, so we don't need
to include it on the config object directly.

Breaking change:
- Rename `r.Scheme` to `r.Scheme()`

Signed-off-by: Scott Andrews <andrewssc@vmware.com>