### PR TITLE
Drop scheme from watcher

### DIFF
--- a/reconcilers/enqueuer.go
+++ b/reconcilers/enqueuer.go
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 package reconcilers
 
 import (
-	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -15,18 +15,13 @@ import (
 	"github.com/vmware-labs/reconciler-runtime/tracker"
 )
 
-func EnqueueTracked(by client.Object, t tracker.Tracker, s *runtime.Scheme) handler.EventHandler {
+func EnqueueTracked(gvk schema.GroupVersionKind, t tracker.Tracker) handler.EventHandler {
 	return handler.EnqueueRequestsFromMapFunc(
 		func(a client.Object) []reconcile.Request {
 			var requests []reconcile.Request
 
-			gvks, _, err := s.ObjectKinds(by)
-			if err != nil {
-				panic(err)
-			}
-
 			key := tracker.NewKey(
-				gvks[0],
+				gvk,
 				types.NamespacedName{Namespace: a.GetNamespace(), Name: a.GetName()},
 			)
 			for _, item := range t.Lookup(key) {

--- a/reconcilers/reconcilers.go
+++ b/reconcilers/reconcilers.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/cache"
 	"k8s.io/client-go/tools/record"
@@ -52,14 +53,13 @@ type Config struct {
 func NewConfig(mgr ctrl.Manager, apiType client.Object, syncPeriod time.Duration) Config {
 	name := typeName(apiType)
 	log := ctrl.Log.WithName("controllers").WithName(name)
-	scheme := mgr.GetScheme()
 	return Config{
 		DuckClient: client.NewDuckClient(mgr.GetClient()),
 		APIReader:  client.NewDuckReader(mgr.GetAPIReader()),
 		Recorder:   mgr.GetEventRecorderFor(name),
 		Log:        log,
-		Tracker: tracker.NewWatcher(syncPeriod, log.WithName("tracker"), scheme, func(by client.Object, t tracker.Tracker) handler.EventHandler {
-			return EnqueueTracked(by, t, scheme)
+		Tracker: tracker.NewWatcher(syncPeriod, log.WithName("tracker"), func(gvk schema.GroupVersionKind, t tracker.Tracker) handler.EventHandler {
+			return EnqueueTracked(gvk, t)
 		}),
 	}
 }


### PR DESCRIPTION
The scheme is a set of known resource types. For duck typed resources,
we do not know the concrete types in advance, so the scheme provides no
value.

Instead of using the scheme, we can use GVKs and Unstructured resources.