### PR TITLE
Fix SyncReconciler passing reflect.Type as key to logger

### DIFF
--- a/reconcilers/reconcilers.go
+++ b/reconcilers/reconcilers.go
@@ -268,7 +268,7 @@ func (r *SyncReconciler) validate(ctx context.Context) error {
 func (r *SyncReconciler) Reconcile(ctx context.Context, parent client.Object) (ctrl.Result, error) {
 	result, err := r.sync(ctx, parent)
 	if err != nil {
-		r.Log.Error(err, "unable to sync", reflect.TypeOf(parent), parent)
+		r.Log.Error(err, "unable to sync", typeName(parent), parent)
 		return ctrl.Result{}, err
 	}
 


### PR DESCRIPTION
This causes logging implementations such as Zap to panic

Signed-off-by: Gabriele Cipriano <gcipriano@vmware.com>

Cheers Sam and @gabrielecipriano