### PR TITLE
Deprecate Test method for table tests

### DIFF
--- a/testing/reconciler.go
+++ b/testing/reconciler.go
@@ -86,8 +86,15 @@ type VerifyFunc func(t *testing.T, result controllerruntime.Result, err error)
 // ReconcilerTestSuite represents a list of reconciler test cases.
 type ReconcilerTestSuite []ReconcilerTestCase
 
+// Deprecated: Use Run instead
 // Test executes the test case.
 func (tc *ReconcilerTestCase) Test(t *testing.T, scheme *runtime.Scheme, factory ReconcilerFactory) {
+	t.Helper()
+	tc.Run(t, scheme, factory)
+}
+
+// Run executes the test case.
+func (tc *ReconcilerTestCase) Run(t *testing.T, scheme *runtime.Scheme, factory ReconcilerFactory) {
 	t.Helper()
 	if tc.Skip {
 		t.SkipNow()
@@ -272,17 +279,24 @@ var (
 	safeDeployDiff = cmpopts.IgnoreUnexported(resource.Quantity{})
 )
 
+// Deprecated: Use Run instead
 // Test executes the reconciler test suite.
-func (tb ReconcilerTestSuite) Test(t *testing.T, scheme *runtime.Scheme, factory ReconcilerFactory) {
+func (ts ReconcilerTestSuite) Test(t *testing.T, scheme *runtime.Scheme, factory ReconcilerFactory) {
+	t.Helper()
+	ts.Run(t, scheme, factory)
+}
+
+// Run executes the reconciler test suite.
+func (ts ReconcilerTestSuite) Run(t *testing.T, scheme *runtime.Scheme, factory ReconcilerFactory) {
 	t.Helper()
 	focussed := ReconcilerTestSuite{}
-	for _, test := range tb {
+	for _, test := range ts {
 		if test.Focus {
 			focussed = append(focussed, test)
 			break
 		}
 	}
-	testsToExecute := tb
+	testsToExecute := ts
 	if len(focussed) > 0 {
 		testsToExecute = focussed
 	}
@@ -293,7 +307,7 @@ func (tb ReconcilerTestSuite) Test(t *testing.T, scheme *runtime.Scheme, factory
 		})
 	}
 	if len(focussed) > 0 {
-		t.Errorf("%d tests out of %d are still focussed, so the test suite fails", len(focussed), len(tb))
+		t.Errorf("%d tests out of %d are still focussed, so the test suite fails", len(focussed), len(ts))
 	}
 }
 

--- a/testing/subreconciler.go
+++ b/testing/subreconciler.go
@@ -87,8 +87,15 @@ type SubReconcilerTestCase struct {
 // SubReconcilerTestSuite represents a list of subreconciler test cases.
 type SubReconcilerTestSuite []SubReconcilerTestCase
 
+// Deprecated: Use Run instead
 // Test executes the test case.
 func (tc *SubReconcilerTestCase) Test(t *testing.T, scheme *runtime.Scheme, factory SubReconcilerFactory) {
+	t.Helper()
+	tc.Run(t, scheme, factory)
+}
+
+// Run executes the test case.
+func (tc *SubReconcilerTestCase) Run(t *testing.T, scheme *runtime.Scheme, factory SubReconcilerFactory) {
 	t.Helper()
 	if tc.Skip {
 		t.SkipNow()
@@ -258,28 +265,35 @@ func (tc *SubReconcilerTestCase) Test(t *testing.T, scheme *runtime.Scheme, fact
 	}
 }
 
+// Deprecated: Use Run instead
 // Test executes the subreconciler test suite.
-func (tb SubReconcilerTestSuite) Test(t *testing.T, scheme *runtime.Scheme, factory SubReconcilerFactory) {
+func (ts SubReconcilerTestSuite) Test(t *testing.T, scheme *runtime.Scheme, factory SubReconcilerFactory) {
+	t.Helper()
+	ts.Run(t, scheme, factory)
+}
+
+// Run executes the subreconciler test suite.
+func (ts SubReconcilerTestSuite) Run(t *testing.T, scheme *runtime.Scheme, factory SubReconcilerFactory) {
 	t.Helper()
 	focussed := SubReconcilerTestSuite{}
-	for _, test := range tb {
+	for _, test := range ts {
 		if test.Focus {
 			focussed = append(focussed, test)
 			break
 		}
 	}
-	testsToExecute := tb
+	testsToExecute := ts
 	if len(focussed) > 0 {
 		testsToExecute = focussed
 	}
 	for _, test := range testsToExecute {
 		t.Run(test.Name, func(t *testing.T) {
 			t.Helper()
-			test.Test(t, scheme, factory)
+			test.Run(t, scheme, factory)
 		})
 	}
 	if len(focussed) > 0 {
-		t.Errorf("%d tests out of %d are still focussed, so the test suite fails", len(focussed), len(tb))
+		t.Errorf("%d tests out of %d are still focussed, so the test suite fails", len(focussed), len(ts))
 	}
 }
 


### PR DESCRIPTION
Use Run method instead. The Test method delegates directly to the Run
method, but may be removed in the future.

Signed-off-by: Scott Andrews <andrewssc@vmware.com>