### PR TITLE
Allow overriding the kubeconfig current-context

### DIFF
--- a/cli/client.go
+++ b/cli/client.go
@@ -81,9 +81,10 @@ func (c *client) RESTMapper() meta.RESTMapper {
 	return c.Client().RESTMapper()
 }
 
-func NewClient(kubeConfigFile string, scheme *runtime.Scheme) Client {
+func NewClient(kubeConfigFile string, currentContext string, scheme *runtime.Scheme) Client {
 	return &client{
 		kubeConfigFile: kubeConfigFile,
+		currentContext: currentContext,
 		scheme:         scheme,
 	}
 }
@@ -91,6 +92,7 @@ func NewClient(kubeConfigFile string, scheme *runtime.Scheme) Client {
 type client struct {
 	defaultNamespace string
 	kubeConfigFile   string
+	currentContext   string
 	scheme           *runtime.Scheme
 	kubeConfig       clientcmd.ClientConfig
 	restConfig       *rest.Config
@@ -102,7 +104,9 @@ func (c *client) lazyLoadKubeConfig() clientcmd.ClientConfig {
 	if c.kubeConfig == nil {
 		loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 		loadingRules.ExplicitPath = c.kubeConfigFile
-		configOverrides := &clientcmd.ConfigOverrides{}
+		configOverrides := &clientcmd.ConfigOverrides{
+			CurrentContext: c.currentContext,
+		}
 		c.kubeConfig = clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
 	}
 	return c.kubeConfig

--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -19,7 +19,7 @@ import (
 func TestNewClient(t *testing.T) {
 	scheme := runtime.NewScheme()
 	rtesting.AddToScheme(scheme)
-	c := NewClient("testdata/.kube/config", scheme)
+	c := NewClient("testdata/.kube/config", "", scheme)
 	r := &rtesting.TestResource{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "my-namespace",

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -15,6 +15,7 @@ import (
 const (
 	AllFlagName                  = "--all"
 	AllNamespacesFlagName        = "--all-namespaces"
+	ContextFlagName              = "--context"
 	DryRunFlagName               = "--dry-run"
 	KubeConfigFlagName           = "--kubeconfig"
 	KubeConfigFlagNameDeprecated = "--kube-config"


### PR DESCRIPTION
The client can be configured with an override for the current-context
defiend within the specified kubeconfig file. This is an easy way to
switch contexts within the same config file for a single command.

Signed-off-by: Scott Andrews <andrewssc@vmware.com>