### PR TITLE
Ignore ResourceVersion in tests with stashed resources

### DIFF
--- a/testing/subreconciler.go
+++ b/testing/subreconciler.go
@@ -200,7 +200,7 @@ func (tc *SubReconcilerTestCase) Run(t *testing.T, scheme *runtime.Scheme, facto
 			expected = f.CreateObject()
 		}
 		actual := reconcilers.RetrieveValue(ctx, key)
-		if diff := cmp.Diff(expected, actual, IgnoreLastTransitionTime, safeDeployDiff, ignoreTypeMeta, cmpopts.EquateEmpty()); diff != "" {
+		if diff := cmp.Diff(expected, actual, IgnoreLastTransitionTime, safeDeployDiff, ignoreTypeMeta, ignoreResourceVersion, cmpopts.EquateEmpty()); diff != "" {
 			t.Errorf("Unexpected stash value %q (-expected, +actual): %s", key, diff)
 		}
 	}


### PR DESCRIPTION
Resources comming from the fake client will have a ResourceVersion
defaulted to 999, but that's not a meaningful change for a stashed
value.

Signed-off-by: Scott Andrews <andrewssc@vmware.com>