### PR TITLE
Deprecate resource factories

### DIFF
--- a/testing/factories/clusterrole.go
+++ b/testing/factories/clusterrole.go
@@ -5,6 +5,10 @@ import (
 
 	rtesting "github.com/vmware-labs/reconciler-runtime/testing"
 	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -14,8 +18,10 @@ type clusterRole struct {
 
 var (
 	_ rtesting.Factory = (*clusterRole)(nil)
+	_ client.Object    = (*clusterRole)(nil)
 )
 
+// Deprecated
 func ClusterRole(seed ...*rbacv1.ClusterRole) *clusterRole {
 	var target *rbacv1.ClusterRole
 	switch len(seed) {
@@ -30,6 +36,41 @@ func ClusterRole(seed ...*rbacv1.ClusterRole) *clusterRole {
 		target: target,
 	}
 }
+
+func (f *clusterRole) DeepCopyObject() runtime.Object                  { return f.CreateObject() }
+func (f *clusterRole) GetObjectKind() schema.ObjectKind                { return f.CreateObject().GetObjectKind() }
+func (f *clusterRole) GetNamespace() string                            { panic("not implemeneted") }
+func (f *clusterRole) SetNamespace(namespace string)                   { panic("not implemeneted") }
+func (f *clusterRole) GetName() string                                 { panic("not implemeneted") }
+func (f *clusterRole) SetName(name string)                             { panic("not implemeneted") }
+func (f *clusterRole) GetGenerateName() string                         { panic("not implemeneted") }
+func (f *clusterRole) SetGenerateName(name string)                     { panic("not implemeneted") }
+func (f *clusterRole) GetUID() types.UID                               { panic("not implemeneted") }
+func (f *clusterRole) SetUID(uid types.UID)                            { panic("not implemeneted") }
+func (f *clusterRole) GetResourceVersion() string                      { panic("not implemeneted") }
+func (f *clusterRole) SetResourceVersion(version string)               { panic("not implemeneted") }
+func (f *clusterRole) GetGeneration() int64                            { panic("not implemeneted") }
+func (f *clusterRole) SetGeneration(generation int64)                  { panic("not implemeneted") }
+func (f *clusterRole) GetSelfLink() string                             { panic("not implemeneted") }
+func (f *clusterRole) SetSelfLink(selfLink string)                     { panic("not implemeneted") }
+func (f *clusterRole) GetCreationTimestamp() metav1.Time               { panic("not implemeneted") }
+func (f *clusterRole) SetCreationTimestamp(timestamp metav1.Time)      { panic("not implemeneted") }
+func (f *clusterRole) GetDeletionTimestamp() *metav1.Time              { panic("not implemeneted") }
+func (f *clusterRole) SetDeletionTimestamp(timestamp *metav1.Time)     { panic("not implemeneted") }
+func (f *clusterRole) GetDeletionGracePeriodSeconds() *int64           { panic("not implemeneted") }
+func (f *clusterRole) SetDeletionGracePeriodSeconds(*int64)            { panic("not implemeneted") }
+func (f *clusterRole) GetLabels() map[string]string                    { panic("not implemeneted") }
+func (f *clusterRole) SetLabels(labels map[string]string)              { panic("not implemeneted") }
+func (f *clusterRole) GetAnnotations() map[string]string               { panic("not implemeneted") }
+func (f *clusterRole) SetAnnotations(annotations map[string]string)    { panic("not implemeneted") }
+func (f *clusterRole) GetFinalizers() []string                         { panic("not implemeneted") }
+func (f *clusterRole) SetFinalizers(finalizers []string)               { panic("not implemeneted") }
+func (f *clusterRole) GetOwnerReferences() []metav1.OwnerReference     { panic("not implemeneted") }
+func (f *clusterRole) SetOwnerReferences([]metav1.OwnerReference)      { panic("not implemeneted") }
+func (f *clusterRole) GetClusterName() string                          { panic("not implemeneted") }
+func (f *clusterRole) SetClusterName(clusterName string)               { panic("not implemeneted") }
+func (f *clusterRole) GetManagedFields() []metav1.ManagedFieldsEntry   { panic("not implemeneted") }
+func (f *clusterRole) SetManagedFields(mf []metav1.ManagedFieldsEntry) { panic("not implemeneted") }
 
 func (f *clusterRole) deepCopy() *clusterRole {
 	return ClusterRole(f.target.DeepCopy())

--- a/testing/factories/clusterrole.go
+++ b/testing/factories/clusterrole.go
@@ -5,14 +5,13 @@ import (
 
 	rtesting "github.com/vmware-labs/reconciler-runtime/testing"
 	rbacv1 "k8s.io/api/rbac/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type clusterRole struct {
+	NullObjectMeta
 	target *rbacv1.ClusterRole
 }
 
@@ -37,40 +36,13 @@ func ClusterRole(seed ...*rbacv1.ClusterRole) *clusterRole {
 	}
 }
 
-func (f *clusterRole) DeepCopyObject() runtime.Object                  { return f.CreateObject() }
-func (f *clusterRole) GetObjectKind() schema.ObjectKind                { return f.CreateObject().GetObjectKind() }
-func (f *clusterRole) GetNamespace() string                            { panic("not implemeneted") }
-func (f *clusterRole) SetNamespace(namespace string)                   { panic("not implemeneted") }
-func (f *clusterRole) GetName() string                                 { panic("not implemeneted") }
-func (f *clusterRole) SetName(name string)                             { panic("not implemeneted") }
-func (f *clusterRole) GetGenerateName() string                         { panic("not implemeneted") }
-func (f *clusterRole) SetGenerateName(name string)                     { panic("not implemeneted") }
-func (f *clusterRole) GetUID() types.UID                               { panic("not implemeneted") }
-func (f *clusterRole) SetUID(uid types.UID)                            { panic("not implemeneted") }
-func (f *clusterRole) GetResourceVersion() string                      { panic("not implemeneted") }
-func (f *clusterRole) SetResourceVersion(version string)               { panic("not implemeneted") }
-func (f *clusterRole) GetGeneration() int64                            { panic("not implemeneted") }
-func (f *clusterRole) SetGeneration(generation int64)                  { panic("not implemeneted") }
-func (f *clusterRole) GetSelfLink() string                             { panic("not implemeneted") }
-func (f *clusterRole) SetSelfLink(selfLink string)                     { panic("not implemeneted") }
-func (f *clusterRole) GetCreationTimestamp() metav1.Time               { panic("not implemeneted") }
-func (f *clusterRole) SetCreationTimestamp(timestamp metav1.Time)      { panic("not implemeneted") }
-func (f *clusterRole) GetDeletionTimestamp() *metav1.Time              { panic("not implemeneted") }
-func (f *clusterRole) SetDeletionTimestamp(timestamp *metav1.Time)     { panic("not implemeneted") }
-func (f *clusterRole) GetDeletionGracePeriodSeconds() *int64           { panic("not implemeneted") }
-func (f *clusterRole) SetDeletionGracePeriodSeconds(*int64)            { panic("not implemeneted") }
-func (f *clusterRole) GetLabels() map[string]string                    { panic("not implemeneted") }
-func (f *clusterRole) SetLabels(labels map[string]string)              { panic("not implemeneted") }
-func (f *clusterRole) GetAnnotations() map[string]string               { panic("not implemeneted") }
-func (f *clusterRole) SetAnnotations(annotations map[string]string)    { panic("not implemeneted") }
-func (f *clusterRole) GetFinalizers() []string                         { panic("not implemeneted") }
-func (f *clusterRole) SetFinalizers(finalizers []string)               { panic("not implemeneted") }
-func (f *clusterRole) GetOwnerReferences() []metav1.OwnerReference     { panic("not implemeneted") }
-func (f *clusterRole) SetOwnerReferences([]metav1.OwnerReference)      { panic("not implemeneted") }
-func (f *clusterRole) GetClusterName() string                          { panic("not implemeneted") }
-func (f *clusterRole) SetClusterName(clusterName string)               { panic("not implemeneted") }
-func (f *clusterRole) GetManagedFields() []metav1.ManagedFieldsEntry   { panic("not implemeneted") }
-func (f *clusterRole) SetManagedFields(mf []metav1.ManagedFieldsEntry) { panic("not implemeneted") }
+func (f *clusterRole) DeepCopyObject() runtime.Object {
+	return f.CreateObject()
+}
+
+func (f *clusterRole) GetObjectKind() schema.ObjectKind {
+	return f.CreateObject().GetObjectKind()
+}
 
 func (f *clusterRole) deepCopy() *clusterRole {
 	return ClusterRole(f.target.DeepCopy())

--- a/testing/factories/clusterrolebinding.go
+++ b/testing/factories/clusterrolebinding.go
@@ -5,14 +5,13 @@ import (
 
 	rtesting "github.com/vmware-labs/reconciler-runtime/testing"
 	rbacv1 "k8s.io/api/rbac/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type clusterRoleBinding struct {
+	NullObjectMeta
 	target *rbacv1.ClusterRoleBinding
 }
 
@@ -37,45 +36,12 @@ func ClusterRoleBinding(seed ...*rbacv1.ClusterRoleBinding) *clusterRoleBinding 
 	}
 }
 
-func (f *clusterRoleBinding) DeepCopyObject() runtime.Object { return f.CreateObject() }
+func (f *clusterRoleBinding) DeepCopyObject() runtime.Object {
+	return f.CreateObject()
+}
+
 func (f *clusterRoleBinding) GetObjectKind() schema.ObjectKind {
 	return f.CreateObject().GetObjectKind()
-}
-func (f *clusterRoleBinding) GetNamespace() string                         { panic("not implemeneted") }
-func (f *clusterRoleBinding) SetNamespace(namespace string)                { panic("not implemeneted") }
-func (f *clusterRoleBinding) GetName() string                              { panic("not implemeneted") }
-func (f *clusterRoleBinding) SetName(name string)                          { panic("not implemeneted") }
-func (f *clusterRoleBinding) GetGenerateName() string                      { panic("not implemeneted") }
-func (f *clusterRoleBinding) SetGenerateName(name string)                  { panic("not implemeneted") }
-func (f *clusterRoleBinding) GetUID() types.UID                            { panic("not implemeneted") }
-func (f *clusterRoleBinding) SetUID(uid types.UID)                         { panic("not implemeneted") }
-func (f *clusterRoleBinding) GetResourceVersion() string                   { panic("not implemeneted") }
-func (f *clusterRoleBinding) SetResourceVersion(version string)            { panic("not implemeneted") }
-func (f *clusterRoleBinding) GetGeneration() int64                         { panic("not implemeneted") }
-func (f *clusterRoleBinding) SetGeneration(generation int64)               { panic("not implemeneted") }
-func (f *clusterRoleBinding) GetSelfLink() string                          { panic("not implemeneted") }
-func (f *clusterRoleBinding) SetSelfLink(selfLink string)                  { panic("not implemeneted") }
-func (f *clusterRoleBinding) GetCreationTimestamp() metav1.Time            { panic("not implemeneted") }
-func (f *clusterRoleBinding) SetCreationTimestamp(timestamp metav1.Time)   { panic("not implemeneted") }
-func (f *clusterRoleBinding) GetDeletionTimestamp() *metav1.Time           { panic("not implemeneted") }
-func (f *clusterRoleBinding) SetDeletionTimestamp(timestamp *metav1.Time)  { panic("not implemeneted") }
-func (f *clusterRoleBinding) GetDeletionGracePeriodSeconds() *int64        { panic("not implemeneted") }
-func (f *clusterRoleBinding) SetDeletionGracePeriodSeconds(*int64)         { panic("not implemeneted") }
-func (f *clusterRoleBinding) GetLabels() map[string]string                 { panic("not implemeneted") }
-func (f *clusterRoleBinding) SetLabels(labels map[string]string)           { panic("not implemeneted") }
-func (f *clusterRoleBinding) GetAnnotations() map[string]string            { panic("not implemeneted") }
-func (f *clusterRoleBinding) SetAnnotations(annotations map[string]string) { panic("not implemeneted") }
-func (f *clusterRoleBinding) GetFinalizers() []string                      { panic("not implemeneted") }
-func (f *clusterRoleBinding) SetFinalizers(finalizers []string)            { panic("not implemeneted") }
-func (f *clusterRoleBinding) GetOwnerReferences() []metav1.OwnerReference  { panic("not implemeneted") }
-func (f *clusterRoleBinding) SetOwnerReferences([]metav1.OwnerReference)   { panic("not implemeneted") }
-func (f *clusterRoleBinding) GetClusterName() string                       { panic("not implemeneted") }
-func (f *clusterRoleBinding) SetClusterName(clusterName string)            { panic("not implemeneted") }
-func (f *clusterRoleBinding) GetManagedFields() []metav1.ManagedFieldsEntry {
-	panic("not implemeneted")
-}
-func (f *clusterRoleBinding) SetManagedFields(mf []metav1.ManagedFieldsEntry) {
-	panic("not implemeneted")
 }
 
 func (f *clusterRoleBinding) deepCopy() *clusterRoleBinding {

--- a/testing/factories/clusterrolebinding.go
+++ b/testing/factories/clusterrolebinding.go
@@ -5,6 +5,10 @@ import (
 
 	rtesting "github.com/vmware-labs/reconciler-runtime/testing"
 	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -14,8 +18,10 @@ type clusterRoleBinding struct {
 
 var (
 	_ rtesting.Factory = (*clusterRoleBinding)(nil)
+	_ client.Object    = (*clusterRoleBinding)(nil)
 )
 
+// Deprecated
 func ClusterRoleBinding(seed ...*rbacv1.ClusterRoleBinding) *clusterRoleBinding {
 	var target *rbacv1.ClusterRoleBinding
 	switch len(seed) {
@@ -29,6 +35,47 @@ func ClusterRoleBinding(seed ...*rbacv1.ClusterRoleBinding) *clusterRoleBinding 
 	return &clusterRoleBinding{
 		target: target,
 	}
+}
+
+func (f *clusterRoleBinding) DeepCopyObject() runtime.Object { return f.CreateObject() }
+func (f *clusterRoleBinding) GetObjectKind() schema.ObjectKind {
+	return f.CreateObject().GetObjectKind()
+}
+func (f *clusterRoleBinding) GetNamespace() string                         { panic("not implemeneted") }
+func (f *clusterRoleBinding) SetNamespace(namespace string)                { panic("not implemeneted") }
+func (f *clusterRoleBinding) GetName() string                              { panic("not implemeneted") }
+func (f *clusterRoleBinding) SetName(name string)                          { panic("not implemeneted") }
+func (f *clusterRoleBinding) GetGenerateName() string                      { panic("not implemeneted") }
+func (f *clusterRoleBinding) SetGenerateName(name string)                  { panic("not implemeneted") }
+func (f *clusterRoleBinding) GetUID() types.UID                            { panic("not implemeneted") }
+func (f *clusterRoleBinding) SetUID(uid types.UID)                         { panic("not implemeneted") }
+func (f *clusterRoleBinding) GetResourceVersion() string                   { panic("not implemeneted") }
+func (f *clusterRoleBinding) SetResourceVersion(version string)            { panic("not implemeneted") }
+func (f *clusterRoleBinding) GetGeneration() int64                         { panic("not implemeneted") }
+func (f *clusterRoleBinding) SetGeneration(generation int64)               { panic("not implemeneted") }
+func (f *clusterRoleBinding) GetSelfLink() string                          { panic("not implemeneted") }
+func (f *clusterRoleBinding) SetSelfLink(selfLink string)                  { panic("not implemeneted") }
+func (f *clusterRoleBinding) GetCreationTimestamp() metav1.Time            { panic("not implemeneted") }
+func (f *clusterRoleBinding) SetCreationTimestamp(timestamp metav1.Time)   { panic("not implemeneted") }
+func (f *clusterRoleBinding) GetDeletionTimestamp() *metav1.Time           { panic("not implemeneted") }
+func (f *clusterRoleBinding) SetDeletionTimestamp(timestamp *metav1.Time)  { panic("not implemeneted") }
+func (f *clusterRoleBinding) GetDeletionGracePeriodSeconds() *int64        { panic("not implemeneted") }
+func (f *clusterRoleBinding) SetDeletionGracePeriodSeconds(*int64)         { panic("not implemeneted") }
+func (f *clusterRoleBinding) GetLabels() map[string]string                 { panic("not implemeneted") }
+func (f *clusterRoleBinding) SetLabels(labels map[string]string)           { panic("not implemeneted") }
+func (f *clusterRoleBinding) GetAnnotations() map[string]string            { panic("not implemeneted") }
+func (f *clusterRoleBinding) SetAnnotations(annotations map[string]string) { panic("not implemeneted") }
+func (f *clusterRoleBinding) GetFinalizers() []string                      { panic("not implemeneted") }
+func (f *clusterRoleBinding) SetFinalizers(finalizers []string)            { panic("not implemeneted") }
+func (f *clusterRoleBinding) GetOwnerReferences() []metav1.OwnerReference  { panic("not implemeneted") }
+func (f *clusterRoleBinding) SetOwnerReferences([]metav1.OwnerReference)   { panic("not implemeneted") }
+func (f *clusterRoleBinding) GetClusterName() string                       { panic("not implemeneted") }
+func (f *clusterRoleBinding) SetClusterName(clusterName string)            { panic("not implemeneted") }
+func (f *clusterRoleBinding) GetManagedFields() []metav1.ManagedFieldsEntry {
+	panic("not implemeneted")
+}
+func (f *clusterRoleBinding) SetManagedFields(mf []metav1.ManagedFieldsEntry) {
+	panic("not implemeneted")
 }
 
 func (f *clusterRoleBinding) deepCopy() *clusterRoleBinding {

--- a/testing/factories/condition.go
+++ b/testing/factories/condition.go
@@ -12,6 +12,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+// Deprecated
 type ConditionFactory interface {
 	Create() apis.Condition
 
@@ -29,6 +30,7 @@ type conditionImpl struct {
 	target *apis.Condition
 }
 
+// Deprecated
 func Condition(seed ...apis.Condition) ConditionFactory {
 	var target *apis.Condition
 	switch len(seed) {

--- a/testing/factories/configmap.go
+++ b/testing/factories/configmap.go
@@ -10,14 +10,13 @@ import (
 
 	rtesting "github.com/vmware-labs/reconciler-runtime/testing"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type configMap struct {
+	NullObjectMeta
 	target *corev1.ConfigMap
 }
 
@@ -42,40 +41,13 @@ func ConfigMap(seed ...*corev1.ConfigMap) *configMap {
 	}
 }
 
-func (f *configMap) DeepCopyObject() runtime.Object                  { return f.CreateObject() }
-func (f *configMap) GetObjectKind() schema.ObjectKind                { return f.CreateObject().GetObjectKind() }
-func (f *configMap) GetNamespace() string                            { panic("not implemeneted") }
-func (f *configMap) SetNamespace(namespace string)                   { panic("not implemeneted") }
-func (f *configMap) GetName() string                                 { panic("not implemeneted") }
-func (f *configMap) SetName(name string)                             { panic("not implemeneted") }
-func (f *configMap) GetGenerateName() string                         { panic("not implemeneted") }
-func (f *configMap) SetGenerateName(name string)                     { panic("not implemeneted") }
-func (f *configMap) GetUID() types.UID                               { panic("not implemeneted") }
-func (f *configMap) SetUID(uid types.UID)                            { panic("not implemeneted") }
-func (f *configMap) GetResourceVersion() string                      { panic("not implemeneted") }
-func (f *configMap) SetResourceVersion(version string)               { panic("not implemeneted") }
-func (f *configMap) GetGeneration() int64                            { panic("not implemeneted") }
-func (f *configMap) SetGeneration(generation int64)                  { panic("not implemeneted") }
-func (f *configMap) GetSelfLink() string                             { panic("not implemeneted") }
-func (f *configMap) SetSelfLink(selfLink string)                     { panic("not implemeneted") }
-func (f *configMap) GetCreationTimestamp() metav1.Time               { panic("not implemeneted") }
-func (f *configMap) SetCreationTimestamp(timestamp metav1.Time)      { panic("not implemeneted") }
-func (f *configMap) GetDeletionTimestamp() *metav1.Time              { panic("not implemeneted") }
-func (f *configMap) SetDeletionTimestamp(timestamp *metav1.Time)     { panic("not implemeneted") }
-func (f *configMap) GetDeletionGracePeriodSeconds() *int64           { panic("not implemeneted") }
-func (f *configMap) SetDeletionGracePeriodSeconds(*int64)            { panic("not implemeneted") }
-func (f *configMap) GetLabels() map[string]string                    { panic("not implemeneted") }
-func (f *configMap) SetLabels(labels map[string]string)              { panic("not implemeneted") }
-func (f *configMap) GetAnnotations() map[string]string               { panic("not implemeneted") }
-func (f *configMap) SetAnnotations(annotations map[string]string)    { panic("not implemeneted") }
-func (f *configMap) GetFinalizers() []string                         { panic("not implemeneted") }
-func (f *configMap) SetFinalizers(finalizers []string)               { panic("not implemeneted") }
-func (f *configMap) GetOwnerReferences() []metav1.OwnerReference     { panic("not implemeneted") }
-func (f *configMap) SetOwnerReferences([]metav1.OwnerReference)      { panic("not implemeneted") }
-func (f *configMap) GetClusterName() string                          { panic("not implemeneted") }
-func (f *configMap) SetClusterName(clusterName string)               { panic("not implemeneted") }
-func (f *configMap) GetManagedFields() []metav1.ManagedFieldsEntry   { panic("not implemeneted") }
-func (f *configMap) SetManagedFields(mf []metav1.ManagedFieldsEntry) { panic("not implemeneted") }
+func (f *configMap) DeepCopyObject() runtime.Object {
+	return f.CreateObject()
+}
+
+func (f *configMap) GetObjectKind() schema.ObjectKind {
+	return f.CreateObject().GetObjectKind()
+}
 
 func (f *configMap) deepCopy() *configMap {
 	return ConfigMap(f.target.DeepCopy())

--- a/testing/factories/configmap.go
+++ b/testing/factories/configmap.go
@@ -10,6 +10,10 @@ import (
 
 	rtesting "github.com/vmware-labs/reconciler-runtime/testing"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -19,8 +23,10 @@ type configMap struct {
 
 var (
 	_ rtesting.Factory = (*configMap)(nil)
+	_ client.Object    = (*configMap)(nil)
 )
 
+// Deprecated
 func ConfigMap(seed ...*corev1.ConfigMap) *configMap {
 	var target *corev1.ConfigMap
 	switch len(seed) {
@@ -35,6 +41,41 @@ func ConfigMap(seed ...*corev1.ConfigMap) *configMap {
 		target: target,
 	}
 }
+
+func (f *configMap) DeepCopyObject() runtime.Object                  { return f.CreateObject() }
+func (f *configMap) GetObjectKind() schema.ObjectKind                { return f.CreateObject().GetObjectKind() }
+func (f *configMap) GetNamespace() string                            { panic("not implemeneted") }
+func (f *configMap) SetNamespace(namespace string)                   { panic("not implemeneted") }
+func (f *configMap) GetName() string                                 { panic("not implemeneted") }
+func (f *configMap) SetName(name string)                             { panic("not implemeneted") }
+func (f *configMap) GetGenerateName() string                         { panic("not implemeneted") }
+func (f *configMap) SetGenerateName(name string)                     { panic("not implemeneted") }
+func (f *configMap) GetUID() types.UID                               { panic("not implemeneted") }
+func (f *configMap) SetUID(uid types.UID)                            { panic("not implemeneted") }
+func (f *configMap) GetResourceVersion() string                      { panic("not implemeneted") }
+func (f *configMap) SetResourceVersion(version string)               { panic("not implemeneted") }
+func (f *configMap) GetGeneration() int64                            { panic("not implemeneted") }
+func (f *configMap) SetGeneration(generation int64)                  { panic("not implemeneted") }
+func (f *configMap) GetSelfLink() string                             { panic("not implemeneted") }
+func (f *configMap) SetSelfLink(selfLink string)                     { panic("not implemeneted") }
+func (f *configMap) GetCreationTimestamp() metav1.Time               { panic("not implemeneted") }
+func (f *configMap) SetCreationTimestamp(timestamp metav1.Time)      { panic("not implemeneted") }
+func (f *configMap) GetDeletionTimestamp() *metav1.Time              { panic("not implemeneted") }
+func (f *configMap) SetDeletionTimestamp(timestamp *metav1.Time)     { panic("not implemeneted") }
+func (f *configMap) GetDeletionGracePeriodSeconds() *int64           { panic("not implemeneted") }
+func (f *configMap) SetDeletionGracePeriodSeconds(*int64)            { panic("not implemeneted") }
+func (f *configMap) GetLabels() map[string]string                    { panic("not implemeneted") }
+func (f *configMap) SetLabels(labels map[string]string)              { panic("not implemeneted") }
+func (f *configMap) GetAnnotations() map[string]string               { panic("not implemeneted") }
+func (f *configMap) SetAnnotations(annotations map[string]string)    { panic("not implemeneted") }
+func (f *configMap) GetFinalizers() []string                         { panic("not implemeneted") }
+func (f *configMap) SetFinalizers(finalizers []string)               { panic("not implemeneted") }
+func (f *configMap) GetOwnerReferences() []metav1.OwnerReference     { panic("not implemeneted") }
+func (f *configMap) SetOwnerReferences([]metav1.OwnerReference)      { panic("not implemeneted") }
+func (f *configMap) GetClusterName() string                          { panic("not implemeneted") }
+func (f *configMap) SetClusterName(clusterName string)               { panic("not implemeneted") }
+func (f *configMap) GetManagedFields() []metav1.ManagedFieldsEntry   { panic("not implemeneted") }
+func (f *configMap) SetManagedFields(mf []metav1.ManagedFieldsEntry) { panic("not implemeneted") }
 
 func (f *configMap) deepCopy() *configMap {
 	return ConfigMap(f.target.DeepCopy())

--- a/testing/factories/deployment.go
+++ b/testing/factories/deployment.go
@@ -12,6 +12,9 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -21,8 +24,10 @@ type deployment struct {
 
 var (
 	_ rtesting.Factory = (*deployment)(nil)
+	_ client.Object    = (*deployment)(nil)
 )
 
+// Deprecated
 func Deployment(seed ...*appsv1.Deployment) *deployment {
 	var target *appsv1.Deployment
 	switch len(seed) {
@@ -37,6 +42,41 @@ func Deployment(seed ...*appsv1.Deployment) *deployment {
 		target: target,
 	}
 }
+
+func (f *deployment) DeepCopyObject() runtime.Object                  { return f.CreateObject() }
+func (f *deployment) GetObjectKind() schema.ObjectKind                { return f.CreateObject().GetObjectKind() }
+func (f *deployment) GetNamespace() string                            { panic("not implemeneted") }
+func (f *deployment) SetNamespace(namespace string)                   { panic("not implemeneted") }
+func (f *deployment) GetName() string                                 { panic("not implemeneted") }
+func (f *deployment) SetName(name string)                             { panic("not implemeneted") }
+func (f *deployment) GetGenerateName() string                         { panic("not implemeneted") }
+func (f *deployment) SetGenerateName(name string)                     { panic("not implemeneted") }
+func (f *deployment) GetUID() types.UID                               { panic("not implemeneted") }
+func (f *deployment) SetUID(uid types.UID)                            { panic("not implemeneted") }
+func (f *deployment) GetResourceVersion() string                      { panic("not implemeneted") }
+func (f *deployment) SetResourceVersion(version string)               { panic("not implemeneted") }
+func (f *deployment) GetGeneration() int64                            { panic("not implemeneted") }
+func (f *deployment) SetGeneration(generation int64)                  { panic("not implemeneted") }
+func (f *deployment) GetSelfLink() string                             { panic("not implemeneted") }
+func (f *deployment) SetSelfLink(selfLink string)                     { panic("not implemeneted") }
+func (f *deployment) GetCreationTimestamp() metav1.Time               { panic("not implemeneted") }
+func (f *deployment) SetCreationTimestamp(timestamp metav1.Time)      { panic("not implemeneted") }
+func (f *deployment) GetDeletionTimestamp() *metav1.Time              { panic("not implemeneted") }
+func (f *deployment) SetDeletionTimestamp(timestamp *metav1.Time)     { panic("not implemeneted") }
+func (f *deployment) GetDeletionGracePeriodSeconds() *int64           { panic("not implemeneted") }
+func (f *deployment) SetDeletionGracePeriodSeconds(*int64)            { panic("not implemeneted") }
+func (f *deployment) GetLabels() map[string]string                    { panic("not implemeneted") }
+func (f *deployment) SetLabels(labels map[string]string)              { panic("not implemeneted") }
+func (f *deployment) GetAnnotations() map[string]string               { panic("not implemeneted") }
+func (f *deployment) SetAnnotations(annotations map[string]string)    { panic("not implemeneted") }
+func (f *deployment) GetFinalizers() []string                         { panic("not implemeneted") }
+func (f *deployment) SetFinalizers(finalizers []string)               { panic("not implemeneted") }
+func (f *deployment) GetOwnerReferences() []metav1.OwnerReference     { panic("not implemeneted") }
+func (f *deployment) SetOwnerReferences([]metav1.OwnerReference)      { panic("not implemeneted") }
+func (f *deployment) GetClusterName() string                          { panic("not implemeneted") }
+func (f *deployment) SetClusterName(clusterName string)               { panic("not implemeneted") }
+func (f *deployment) GetManagedFields() []metav1.ManagedFieldsEntry   { panic("not implemeneted") }
+func (f *deployment) SetManagedFields(mf []metav1.ManagedFieldsEntry) { panic("not implemeneted") }
 
 func (f *deployment) deepCopy() *deployment {
 	return Deployment(f.target.DeepCopy())

--- a/testing/factories/deployment.go
+++ b/testing/factories/deployment.go
@@ -14,11 +14,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type deployment struct {
+	NullObjectMeta
 	target *appsv1.Deployment
 }
 
@@ -43,40 +43,13 @@ func Deployment(seed ...*appsv1.Deployment) *deployment {
 	}
 }
 
-func (f *deployment) DeepCopyObject() runtime.Object                  { return f.CreateObject() }
-func (f *deployment) GetObjectKind() schema.ObjectKind                { return f.CreateObject().GetObjectKind() }
-func (f *deployment) GetNamespace() string                            { panic("not implemeneted") }
-func (f *deployment) SetNamespace(namespace string)                   { panic("not implemeneted") }
-func (f *deployment) GetName() string                                 { panic("not implemeneted") }
-func (f *deployment) SetName(name string)                             { panic("not implemeneted") }
-func (f *deployment) GetGenerateName() string                         { panic("not implemeneted") }
-func (f *deployment) SetGenerateName(name string)                     { panic("not implemeneted") }
-func (f *deployment) GetUID() types.UID                               { panic("not implemeneted") }
-func (f *deployment) SetUID(uid types.UID)                            { panic("not implemeneted") }
-func (f *deployment) GetResourceVersion() string                      { panic("not implemeneted") }
-func (f *deployment) SetResourceVersion(version string)               { panic("not implemeneted") }
-func (f *deployment) GetGeneration() int64                            { panic("not implemeneted") }
-func (f *deployment) SetGeneration(generation int64)                  { panic("not implemeneted") }
-func (f *deployment) GetSelfLink() string                             { panic("not implemeneted") }
-func (f *deployment) SetSelfLink(selfLink string)                     { panic("not implemeneted") }
-func (f *deployment) GetCreationTimestamp() metav1.Time               { panic("not implemeneted") }
-func (f *deployment) SetCreationTimestamp(timestamp metav1.Time)      { panic("not implemeneted") }
-func (f *deployment) GetDeletionTimestamp() *metav1.Time              { panic("not implemeneted") }
-func (f *deployment) SetDeletionTimestamp(timestamp *metav1.Time)     { panic("not implemeneted") }
-func (f *deployment) GetDeletionGracePeriodSeconds() *int64           { panic("not implemeneted") }
-func (f *deployment) SetDeletionGracePeriodSeconds(*int64)            { panic("not implemeneted") }
-func (f *deployment) GetLabels() map[string]string                    { panic("not implemeneted") }
-func (f *deployment) SetLabels(labels map[string]string)              { panic("not implemeneted") }
-func (f *deployment) GetAnnotations() map[string]string               { panic("not implemeneted") }
-func (f *deployment) SetAnnotations(annotations map[string]string)    { panic("not implemeneted") }
-func (f *deployment) GetFinalizers() []string                         { panic("not implemeneted") }
-func (f *deployment) SetFinalizers(finalizers []string)               { panic("not implemeneted") }
-func (f *deployment) GetOwnerReferences() []metav1.OwnerReference     { panic("not implemeneted") }
-func (f *deployment) SetOwnerReferences([]metav1.OwnerReference)      { panic("not implemeneted") }
-func (f *deployment) GetClusterName() string                          { panic("not implemeneted") }
-func (f *deployment) SetClusterName(clusterName string)               { panic("not implemeneted") }
-func (f *deployment) GetManagedFields() []metav1.ManagedFieldsEntry   { panic("not implemeneted") }
-func (f *deployment) SetManagedFields(mf []metav1.ManagedFieldsEntry) { panic("not implemeneted") }
+func (f *deployment) DeepCopyObject() runtime.Object {
+	return f.CreateObject()
+}
+
+func (f *deployment) GetObjectKind() schema.ObjectKind {
+	return f.CreateObject().GetObjectKind()
+}
 
 func (f *deployment) deepCopy() *deployment {
 	return Deployment(f.target.DeepCopy())

--- a/testing/factories/ingress.go
+++ b/testing/factories/ingress.go
@@ -11,6 +11,10 @@ import (
 	rtesting "github.com/vmware-labs/reconciler-runtime/testing"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -21,8 +25,10 @@ type ingress struct {
 
 var (
 	_ rtesting.Factory = (*ingress)(nil)
+	_ client.Object    = (*ingress)(nil)
 )
 
+// Deprecated
 func Ingress(seed ...*networkingv1beta1.Ingress) *ingress {
 	var target *networkingv1beta1.Ingress
 	switch len(seed) {
@@ -37,6 +43,41 @@ func Ingress(seed ...*networkingv1beta1.Ingress) *ingress {
 		target: target,
 	}
 }
+
+func (f *ingress) DeepCopyObject() runtime.Object                  { return f.CreateObject() }
+func (f *ingress) GetObjectKind() schema.ObjectKind                { return f.CreateObject().GetObjectKind() }
+func (f *ingress) GetNamespace() string                            { panic("not implemeneted") }
+func (f *ingress) SetNamespace(namespace string)                   { panic("not implemeneted") }
+func (f *ingress) GetName() string                                 { panic("not implemeneted") }
+func (f *ingress) SetName(name string)                             { panic("not implemeneted") }
+func (f *ingress) GetGenerateName() string                         { panic("not implemeneted") }
+func (f *ingress) SetGenerateName(name string)                     { panic("not implemeneted") }
+func (f *ingress) GetUID() types.UID                               { panic("not implemeneted") }
+func (f *ingress) SetUID(uid types.UID)                            { panic("not implemeneted") }
+func (f *ingress) GetResourceVersion() string                      { panic("not implemeneted") }
+func (f *ingress) SetResourceVersion(version string)               { panic("not implemeneted") }
+func (f *ingress) GetGeneration() int64                            { panic("not implemeneted") }
+func (f *ingress) SetGeneration(generation int64)                  { panic("not implemeneted") }
+func (f *ingress) GetSelfLink() string                             { panic("not implemeneted") }
+func (f *ingress) SetSelfLink(selfLink string)                     { panic("not implemeneted") }
+func (f *ingress) GetCreationTimestamp() metav1.Time               { panic("not implemeneted") }
+func (f *ingress) SetCreationTimestamp(timestamp metav1.Time)      { panic("not implemeneted") }
+func (f *ingress) GetDeletionTimestamp() *metav1.Time              { panic("not implemeneted") }
+func (f *ingress) SetDeletionTimestamp(timestamp *metav1.Time)     { panic("not implemeneted") }
+func (f *ingress) GetDeletionGracePeriodSeconds() *int64           { panic("not implemeneted") }
+func (f *ingress) SetDeletionGracePeriodSeconds(*int64)            { panic("not implemeneted") }
+func (f *ingress) GetLabels() map[string]string                    { panic("not implemeneted") }
+func (f *ingress) SetLabels(labels map[string]string)              { panic("not implemeneted") }
+func (f *ingress) GetAnnotations() map[string]string               { panic("not implemeneted") }
+func (f *ingress) SetAnnotations(annotations map[string]string)    { panic("not implemeneted") }
+func (f *ingress) GetFinalizers() []string                         { panic("not implemeneted") }
+func (f *ingress) SetFinalizers(finalizers []string)               { panic("not implemeneted") }
+func (f *ingress) GetOwnerReferences() []metav1.OwnerReference     { panic("not implemeneted") }
+func (f *ingress) SetOwnerReferences([]metav1.OwnerReference)      { panic("not implemeneted") }
+func (f *ingress) GetClusterName() string                          { panic("not implemeneted") }
+func (f *ingress) SetClusterName(clusterName string)               { panic("not implemeneted") }
+func (f *ingress) GetManagedFields() []metav1.ManagedFieldsEntry   { panic("not implemeneted") }
+func (f *ingress) SetManagedFields(mf []metav1.ManagedFieldsEntry) { panic("not implemeneted") }
 
 func (f *ingress) deepCopy() *ingress {
 	return Ingress(f.target.DeepCopy())

--- a/testing/factories/ingress.go
+++ b/testing/factories/ingress.go
@@ -11,15 +11,14 @@ import (
 	rtesting "github.com/vmware-labs/reconciler-runtime/testing"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type ingress struct {
+	NullObjectMeta
 	target *networkingv1beta1.Ingress
 }
 
@@ -44,40 +43,13 @@ func Ingress(seed ...*networkingv1beta1.Ingress) *ingress {
 	}
 }
 
-func (f *ingress) DeepCopyObject() runtime.Object                  { return f.CreateObject() }
-func (f *ingress) GetObjectKind() schema.ObjectKind                { return f.CreateObject().GetObjectKind() }
-func (f *ingress) GetNamespace() string                            { panic("not implemeneted") }
-func (f *ingress) SetNamespace(namespace string)                   { panic("not implemeneted") }
-func (f *ingress) GetName() string                                 { panic("not implemeneted") }
-func (f *ingress) SetName(name string)                             { panic("not implemeneted") }
-func (f *ingress) GetGenerateName() string                         { panic("not implemeneted") }
-func (f *ingress) SetGenerateName(name string)                     { panic("not implemeneted") }
-func (f *ingress) GetUID() types.UID                               { panic("not implemeneted") }
-func (f *ingress) SetUID(uid types.UID)                            { panic("not implemeneted") }
-func (f *ingress) GetResourceVersion() string                      { panic("not implemeneted") }
-func (f *ingress) SetResourceVersion(version string)               { panic("not implemeneted") }
-func (f *ingress) GetGeneration() int64                            { panic("not implemeneted") }
-func (f *ingress) SetGeneration(generation int64)                  { panic("not implemeneted") }
-func (f *ingress) GetSelfLink() string                             { panic("not implemeneted") }
-func (f *ingress) SetSelfLink(selfLink string)                     { panic("not implemeneted") }
-func (f *ingress) GetCreationTimestamp() metav1.Time               { panic("not implemeneted") }
-func (f *ingress) SetCreationTimestamp(timestamp metav1.Time)      { panic("not implemeneted") }
-func (f *ingress) GetDeletionTimestamp() *metav1.Time              { panic("not implemeneted") }
-func (f *ingress) SetDeletionTimestamp(timestamp *metav1.Time)     { panic("not implemeneted") }
-func (f *ingress) GetDeletionGracePeriodSeconds() *int64           { panic("not implemeneted") }
-func (f *ingress) SetDeletionGracePeriodSeconds(*int64)            { panic("not implemeneted") }
-func (f *ingress) GetLabels() map[string]string                    { panic("not implemeneted") }
-func (f *ingress) SetLabels(labels map[string]string)              { panic("not implemeneted") }
-func (f *ingress) GetAnnotations() map[string]string               { panic("not implemeneted") }
-func (f *ingress) SetAnnotations(annotations map[string]string)    { panic("not implemeneted") }
-func (f *ingress) GetFinalizers() []string                         { panic("not implemeneted") }
-func (f *ingress) SetFinalizers(finalizers []string)               { panic("not implemeneted") }
-func (f *ingress) GetOwnerReferences() []metav1.OwnerReference     { panic("not implemeneted") }
-func (f *ingress) SetOwnerReferences([]metav1.OwnerReference)      { panic("not implemeneted") }
-func (f *ingress) GetClusterName() string                          { panic("not implemeneted") }
-func (f *ingress) SetClusterName(clusterName string)               { panic("not implemeneted") }
-func (f *ingress) GetManagedFields() []metav1.ManagedFieldsEntry   { panic("not implemeneted") }
-func (f *ingress) SetManagedFields(mf []metav1.ManagedFieldsEntry) { panic("not implemeneted") }
+func (f *ingress) DeepCopyObject() runtime.Object {
+	return f.CreateObject()
+}
+
+func (f *ingress) GetObjectKind() schema.ObjectKind {
+	return f.CreateObject().GetObjectKind()
+}
 
 func (f *ingress) deepCopy() *ingress {
 	return Ingress(f.target.DeepCopy())

--- a/testing/factories/objectmeta.go
+++ b/testing/factories/objectmeta.go
@@ -8,13 +8,14 @@ package factories
 import (
 	"fmt"
 
-	"github.com/vmware-labs/reconciler-runtime/testing"
+	rtesting "github.com/vmware-labs/reconciler-runtime/testing"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
+// Deprecated
 type ObjectMeta interface {
 	Create() metav1.ObjectMeta
 
@@ -24,7 +25,7 @@ type ObjectMeta interface {
 	AddLabel(key, value string) ObjectMeta
 	AddAnnotation(key, value string) ObjectMeta
 	Generation(generation int64) ObjectMeta
-	ControlledBy(owner testing.Factory, scheme *runtime.Scheme) ObjectMeta
+	ControlledBy(owner rtesting.Factory, scheme *runtime.Scheme) ObjectMeta
 	Created(sec int64) ObjectMeta
 	Deleted(sec int64) ObjectMeta
 	UID(uid string) ObjectMeta
@@ -34,6 +35,7 @@ type objectMetaImpl struct {
 	target *metav1.ObjectMeta
 }
 
+// Deprecated
 func ObjectMetaFactory(seed metav1.ObjectMeta) ObjectMeta {
 	return &objectMetaImpl{
 		target: &seed,
@@ -91,7 +93,7 @@ func (f *objectMetaImpl) Generation(generation int64) ObjectMeta {
 	})
 }
 
-func (f *objectMetaImpl) ControlledBy(owner testing.Factory, scheme *runtime.Scheme) ObjectMeta {
+func (f *objectMetaImpl) ControlledBy(owner rtesting.Factory, scheme *runtime.Scheme) ObjectMeta {
 	return f.mutate(func(om *metav1.ObjectMeta) {
 		err := ctrl.SetControllerReference(owner.CreateObject(), om, scheme)
 		if err != nil {

--- a/testing/factories/objectmeta.go
+++ b/testing/factories/objectmeta.go
@@ -121,3 +121,39 @@ func (f *objectMetaImpl) UID(uid string) ObjectMeta {
 		om.UID = types.UID(uid)
 	})
 }
+
+// Deprecated
+type NullObjectMeta struct{}
+
+func (*NullObjectMeta) GetNamespace() string                           { panic("not implemeneted") }
+func (*NullObjectMeta) SetNamespace(_ string)                          { panic("not implemeneted") }
+func (*NullObjectMeta) GetName() string                                { panic("not implemeneted") }
+func (*NullObjectMeta) SetName(_ string)                               { panic("not implemeneted") }
+func (*NullObjectMeta) GetGenerateName() string                        { panic("not implemeneted") }
+func (*NullObjectMeta) SetGenerateName(_ string)                       { panic("not implemeneted") }
+func (*NullObjectMeta) GetUID() types.UID                              { panic("not implemeneted") }
+func (*NullObjectMeta) SetUID(_ types.UID)                             { panic("not implemeneted") }
+func (*NullObjectMeta) GetResourceVersion() string                     { panic("not implemeneted") }
+func (*NullObjectMeta) SetResourceVersion(_ string)                    { panic("not implemeneted") }
+func (*NullObjectMeta) GetGeneration() int64                           { panic("not implemeneted") }
+func (*NullObjectMeta) SetGeneration(_ int64)                          { panic("not implemeneted") }
+func (*NullObjectMeta) GetSelfLink() string                            { panic("not implemeneted") }
+func (*NullObjectMeta) SetSelfLink(_ string)                           { panic("not implemeneted") }
+func (*NullObjectMeta) GetCreationTimestamp() metav1.Time              { panic("not implemeneted") }
+func (*NullObjectMeta) SetCreationTimestamp(_ metav1.Time)             { panic("not implemeneted") }
+func (*NullObjectMeta) GetDeletionTimestamp() *metav1.Time             { panic("not implemeneted") }
+func (*NullObjectMeta) SetDeletionTimestamp(_ *metav1.Time)            { panic("not implemeneted") }
+func (*NullObjectMeta) GetDeletionGracePeriodSeconds() *int64          { panic("not implemeneted") }
+func (*NullObjectMeta) SetDeletionGracePeriodSeconds(*int64)           { panic("not implemeneted") }
+func (*NullObjectMeta) GetLabels() map[string]string                   { panic("not implemeneted") }
+func (*NullObjectMeta) SetLabels(_ map[string]string)                  { panic("not implemeneted") }
+func (*NullObjectMeta) GetAnnotations() map[string]string              { panic("not implemeneted") }
+func (*NullObjectMeta) SetAnnotations(_ map[string]string)             { panic("not implemeneted") }
+func (*NullObjectMeta) GetFinalizers() []string                        { panic("not implemeneted") }
+func (*NullObjectMeta) SetFinalizers(_ []string)                       { panic("not implemeneted") }
+func (*NullObjectMeta) GetOwnerReferences() []metav1.OwnerReference    { panic("not implemeneted") }
+func (*NullObjectMeta) SetOwnerReferences([]metav1.OwnerReference)     { panic("not implemeneted") }
+func (*NullObjectMeta) GetClusterName() string                         { panic("not implemeneted") }
+func (*NullObjectMeta) SetClusterName(_ string)                        { panic("not implemeneted") }
+func (*NullObjectMeta) GetManagedFields() []metav1.ManagedFieldsEntry  { panic("not implemeneted") }
+func (*NullObjectMeta) SetManagedFields(_ []metav1.ManagedFieldsEntry) { panic("not implemeneted") }

--- a/testing/factories/podtemplatespec.go
+++ b/testing/factories/podtemplatespec.go
@@ -9,6 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+// Deprecated
 type PodTemplateSpec interface {
 	Create() corev1.PodTemplateSpec
 
@@ -25,6 +26,7 @@ type podTemplateSpecImpl struct {
 	target *corev1.PodTemplateSpec
 }
 
+// Deprecated
 func PodTemplateSpecFactory(seed corev1.PodTemplateSpec) PodTemplateSpec {
 	return &podTemplateSpecImpl{
 		target: &seed,
@@ -99,7 +101,7 @@ func (f *podTemplateSpecImpl) ServiceAccountName(name string) PodTemplateSpec {
 	})
 }
 
-func(f *podTemplateSpecImpl) ImagePullSecrets(imagePullSecrets ...corev1.LocalObjectReference) PodTemplateSpec {
+func (f *podTemplateSpecImpl) ImagePullSecrets(imagePullSecrets ...corev1.LocalObjectReference) PodTemplateSpec {
 	return f.mutate(func(pts *corev1.PodTemplateSpec) {
 		pts.Spec.ImagePullSecrets = imagePullSecrets
 	})

--- a/testing/factories/role.go
+++ b/testing/factories/role.go
@@ -10,6 +10,10 @@ import (
 
 	rtesting "github.com/vmware-labs/reconciler-runtime/testing"
 	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -19,8 +23,10 @@ type role struct {
 
 var (
 	_ rtesting.Factory = (*role)(nil)
+	_ client.Object    = (*role)(nil)
 )
 
+// Deprecated
 func Role(seed ...*rbacv1.Role) *role {
 	var target *rbacv1.Role
 	switch len(seed) {
@@ -35,6 +41,41 @@ func Role(seed ...*rbacv1.Role) *role {
 		target: target,
 	}
 }
+
+func (f *role) DeepCopyObject() runtime.Object                  { return f.CreateObject() }
+func (f *role) GetObjectKind() schema.ObjectKind                { return f.CreateObject().GetObjectKind() }
+func (f *role) GetNamespace() string                            { panic("not implemeneted") }
+func (f *role) SetNamespace(namespace string)                   { panic("not implemeneted") }
+func (f *role) GetName() string                                 { panic("not implemeneted") }
+func (f *role) SetName(name string)                             { panic("not implemeneted") }
+func (f *role) GetGenerateName() string                         { panic("not implemeneted") }
+func (f *role) SetGenerateName(name string)                     { panic("not implemeneted") }
+func (f *role) GetUID() types.UID                               { panic("not implemeneted") }
+func (f *role) SetUID(uid types.UID)                            { panic("not implemeneted") }
+func (f *role) GetResourceVersion() string                      { panic("not implemeneted") }
+func (f *role) SetResourceVersion(version string)               { panic("not implemeneted") }
+func (f *role) GetGeneration() int64                            { panic("not implemeneted") }
+func (f *role) SetGeneration(generation int64)                  { panic("not implemeneted") }
+func (f *role) GetSelfLink() string                             { panic("not implemeneted") }
+func (f *role) SetSelfLink(selfLink string)                     { panic("not implemeneted") }
+func (f *role) GetCreationTimestamp() metav1.Time               { panic("not implemeneted") }
+func (f *role) SetCreationTimestamp(timestamp metav1.Time)      { panic("not implemeneted") }
+func (f *role) GetDeletionTimestamp() *metav1.Time              { panic("not implemeneted") }
+func (f *role) SetDeletionTimestamp(timestamp *metav1.Time)     { panic("not implemeneted") }
+func (f *role) GetDeletionGracePeriodSeconds() *int64           { panic("not implemeneted") }
+func (f *role) SetDeletionGracePeriodSeconds(*int64)            { panic("not implemeneted") }
+func (f *role) GetLabels() map[string]string                    { panic("not implemeneted") }
+func (f *role) SetLabels(labels map[string]string)              { panic("not implemeneted") }
+func (f *role) GetAnnotations() map[string]string               { panic("not implemeneted") }
+func (f *role) SetAnnotations(annotations map[string]string)    { panic("not implemeneted") }
+func (f *role) GetFinalizers() []string                         { panic("not implemeneted") }
+func (f *role) SetFinalizers(finalizers []string)               { panic("not implemeneted") }
+func (f *role) GetOwnerReferences() []metav1.OwnerReference     { panic("not implemeneted") }
+func (f *role) SetOwnerReferences([]metav1.OwnerReference)      { panic("not implemeneted") }
+func (f *role) GetClusterName() string                          { panic("not implemeneted") }
+func (f *role) SetClusterName(clusterName string)               { panic("not implemeneted") }
+func (f *role) GetManagedFields() []metav1.ManagedFieldsEntry   { panic("not implemeneted") }
+func (f *role) SetManagedFields(mf []metav1.ManagedFieldsEntry) { panic("not implemeneted") }
 
 func (f *role) deepCopy() *role {
 	return Role(f.target.DeepCopy())

--- a/testing/factories/role.go
+++ b/testing/factories/role.go
@@ -10,14 +10,13 @@ import (
 
 	rtesting "github.com/vmware-labs/reconciler-runtime/testing"
 	rbacv1 "k8s.io/api/rbac/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type role struct {
+	NullObjectMeta
 	target *rbacv1.Role
 }
 
@@ -42,40 +41,13 @@ func Role(seed ...*rbacv1.Role) *role {
 	}
 }
 
-func (f *role) DeepCopyObject() runtime.Object                  { return f.CreateObject() }
-func (f *role) GetObjectKind() schema.ObjectKind                { return f.CreateObject().GetObjectKind() }
-func (f *role) GetNamespace() string                            { panic("not implemeneted") }
-func (f *role) SetNamespace(namespace string)                   { panic("not implemeneted") }
-func (f *role) GetName() string                                 { panic("not implemeneted") }
-func (f *role) SetName(name string)                             { panic("not implemeneted") }
-func (f *role) GetGenerateName() string                         { panic("not implemeneted") }
-func (f *role) SetGenerateName(name string)                     { panic("not implemeneted") }
-func (f *role) GetUID() types.UID                               { panic("not implemeneted") }
-func (f *role) SetUID(uid types.UID)                            { panic("not implemeneted") }
-func (f *role) GetResourceVersion() string                      { panic("not implemeneted") }
-func (f *role) SetResourceVersion(version string)               { panic("not implemeneted") }
-func (f *role) GetGeneration() int64                            { panic("not implemeneted") }
-func (f *role) SetGeneration(generation int64)                  { panic("not implemeneted") }
-func (f *role) GetSelfLink() string                             { panic("not implemeneted") }
-func (f *role) SetSelfLink(selfLink string)                     { panic("not implemeneted") }
-func (f *role) GetCreationTimestamp() metav1.Time               { panic("not implemeneted") }
-func (f *role) SetCreationTimestamp(timestamp metav1.Time)      { panic("not implemeneted") }
-func (f *role) GetDeletionTimestamp() *metav1.Time              { panic("not implemeneted") }
-func (f *role) SetDeletionTimestamp(timestamp *metav1.Time)     { panic("not implemeneted") }
-func (f *role) GetDeletionGracePeriodSeconds() *int64           { panic("not implemeneted") }
-func (f *role) SetDeletionGracePeriodSeconds(*int64)            { panic("not implemeneted") }
-func (f *role) GetLabels() map[string]string                    { panic("not implemeneted") }
-func (f *role) SetLabels(labels map[string]string)              { panic("not implemeneted") }
-func (f *role) GetAnnotations() map[string]string               { panic("not implemeneted") }
-func (f *role) SetAnnotations(annotations map[string]string)    { panic("not implemeneted") }
-func (f *role) GetFinalizers() []string                         { panic("not implemeneted") }
-func (f *role) SetFinalizers(finalizers []string)               { panic("not implemeneted") }
-func (f *role) GetOwnerReferences() []metav1.OwnerReference     { panic("not implemeneted") }
-func (f *role) SetOwnerReferences([]metav1.OwnerReference)      { panic("not implemeneted") }
-func (f *role) GetClusterName() string                          { panic("not implemeneted") }
-func (f *role) SetClusterName(clusterName string)               { panic("not implemeneted") }
-func (f *role) GetManagedFields() []metav1.ManagedFieldsEntry   { panic("not implemeneted") }
-func (f *role) SetManagedFields(mf []metav1.ManagedFieldsEntry) { panic("not implemeneted") }
+func (f *role) DeepCopyObject() runtime.Object {
+	return f.CreateObject()
+}
+
+func (f *role) GetObjectKind() schema.ObjectKind {
+	return f.CreateObject().GetObjectKind()
+}
 
 func (f *role) deepCopy() *role {
 	return Role(f.target.DeepCopy())

--- a/testing/factories/rolebinding.go
+++ b/testing/factories/rolebinding.go
@@ -10,14 +10,13 @@ import (
 
 	rtesting "github.com/vmware-labs/reconciler-runtime/testing"
 	rbacv1 "k8s.io/api/rbac/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type rolebinding struct {
+	NullObjectMeta
 	target *rbacv1.RoleBinding
 }
 
@@ -42,40 +41,13 @@ func RoleBinding(seed ...*rbacv1.RoleBinding) *rolebinding {
 	}
 }
 
-func (f *rolebinding) DeepCopyObject() runtime.Object                  { return f.CreateObject() }
-func (f *rolebinding) GetObjectKind() schema.ObjectKind                { return f.CreateObject().GetObjectKind() }
-func (f *rolebinding) GetNamespace() string                            { panic("not implemeneted") }
-func (f *rolebinding) SetNamespace(namespace string)                   { panic("not implemeneted") }
-func (f *rolebinding) GetName() string                                 { panic("not implemeneted") }
-func (f *rolebinding) SetName(name string)                             { panic("not implemeneted") }
-func (f *rolebinding) GetGenerateName() string                         { panic("not implemeneted") }
-func (f *rolebinding) SetGenerateName(name string)                     { panic("not implemeneted") }
-func (f *rolebinding) GetUID() types.UID                               { panic("not implemeneted") }
-func (f *rolebinding) SetUID(uid types.UID)                            { panic("not implemeneted") }
-func (f *rolebinding) GetResourceVersion() string                      { panic("not implemeneted") }
-func (f *rolebinding) SetResourceVersion(version string)               { panic("not implemeneted") }
-func (f *rolebinding) GetGeneration() int64                            { panic("not implemeneted") }
-func (f *rolebinding) SetGeneration(generation int64)                  { panic("not implemeneted") }
-func (f *rolebinding) GetSelfLink() string                             { panic("not implemeneted") }
-func (f *rolebinding) SetSelfLink(selfLink string)                     { panic("not implemeneted") }
-func (f *rolebinding) GetCreationTimestamp() metav1.Time               { panic("not implemeneted") }
-func (f *rolebinding) SetCreationTimestamp(timestamp metav1.Time)      { panic("not implemeneted") }
-func (f *rolebinding) GetDeletionTimestamp() *metav1.Time              { panic("not implemeneted") }
-func (f *rolebinding) SetDeletionTimestamp(timestamp *metav1.Time)     { panic("not implemeneted") }
-func (f *rolebinding) GetDeletionGracePeriodSeconds() *int64           { panic("not implemeneted") }
-func (f *rolebinding) SetDeletionGracePeriodSeconds(*int64)            { panic("not implemeneted") }
-func (f *rolebinding) GetLabels() map[string]string                    { panic("not implemeneted") }
-func (f *rolebinding) SetLabels(labels map[string]string)              { panic("not implemeneted") }
-func (f *rolebinding) GetAnnotations() map[string]string               { panic("not implemeneted") }
-func (f *rolebinding) SetAnnotations(annotations map[string]string)    { panic("not implemeneted") }
-func (f *rolebinding) GetFinalizers() []string                         { panic("not implemeneted") }
-func (f *rolebinding) SetFinalizers(finalizers []string)               { panic("not implemeneted") }
-func (f *rolebinding) GetOwnerReferences() []metav1.OwnerReference     { panic("not implemeneted") }
-func (f *rolebinding) SetOwnerReferences([]metav1.OwnerReference)      { panic("not implemeneted") }
-func (f *rolebinding) GetClusterName() string                          { panic("not implemeneted") }
-func (f *rolebinding) SetClusterName(clusterName string)               { panic("not implemeneted") }
-func (f *rolebinding) GetManagedFields() []metav1.ManagedFieldsEntry   { panic("not implemeneted") }
-func (f *rolebinding) SetManagedFields(mf []metav1.ManagedFieldsEntry) { panic("not implemeneted") }
+func (f *rolebinding) DeepCopyObject() runtime.Object {
+	return f.CreateObject()
+}
+
+func (f *rolebinding) GetObjectKind() schema.ObjectKind {
+	return f.CreateObject().GetObjectKind()
+}
 
 func (f *rolebinding) deepCopy() *rolebinding {
 	return RoleBinding(f.target.DeepCopy())

--- a/testing/factories/rolebinding.go
+++ b/testing/factories/rolebinding.go
@@ -10,6 +10,10 @@ import (
 
 	rtesting "github.com/vmware-labs/reconciler-runtime/testing"
 	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -19,8 +23,10 @@ type rolebinding struct {
 
 var (
 	_ rtesting.Factory = (*rolebinding)(nil)
+	_ client.Object    = (*rolebinding)(nil)
 )
 
+// Deprecated
 func RoleBinding(seed ...*rbacv1.RoleBinding) *rolebinding {
 	var target *rbacv1.RoleBinding
 	switch len(seed) {
@@ -35,6 +41,41 @@ func RoleBinding(seed ...*rbacv1.RoleBinding) *rolebinding {
 		target: target,
 	}
 }
+
+func (f *rolebinding) DeepCopyObject() runtime.Object                  { return f.CreateObject() }
+func (f *rolebinding) GetObjectKind() schema.ObjectKind                { return f.CreateObject().GetObjectKind() }
+func (f *rolebinding) GetNamespace() string                            { panic("not implemeneted") }
+func (f *rolebinding) SetNamespace(namespace string)                   { panic("not implemeneted") }
+func (f *rolebinding) GetName() string                                 { panic("not implemeneted") }
+func (f *rolebinding) SetName(name string)                             { panic("not implemeneted") }
+func (f *rolebinding) GetGenerateName() string                         { panic("not implemeneted") }
+func (f *rolebinding) SetGenerateName(name string)                     { panic("not implemeneted") }
+func (f *rolebinding) GetUID() types.UID                               { panic("not implemeneted") }
+func (f *rolebinding) SetUID(uid types.UID)                            { panic("not implemeneted") }
+func (f *rolebinding) GetResourceVersion() string                      { panic("not implemeneted") }
+func (f *rolebinding) SetResourceVersion(version string)               { panic("not implemeneted") }
+func (f *rolebinding) GetGeneration() int64                            { panic("not implemeneted") }
+func (f *rolebinding) SetGeneration(generation int64)                  { panic("not implemeneted") }
+func (f *rolebinding) GetSelfLink() string                             { panic("not implemeneted") }
+func (f *rolebinding) SetSelfLink(selfLink string)                     { panic("not implemeneted") }
+func (f *rolebinding) GetCreationTimestamp() metav1.Time               { panic("not implemeneted") }
+func (f *rolebinding) SetCreationTimestamp(timestamp metav1.Time)      { panic("not implemeneted") }
+func (f *rolebinding) GetDeletionTimestamp() *metav1.Time              { panic("not implemeneted") }
+func (f *rolebinding) SetDeletionTimestamp(timestamp *metav1.Time)     { panic("not implemeneted") }
+func (f *rolebinding) GetDeletionGracePeriodSeconds() *int64           { panic("not implemeneted") }
+func (f *rolebinding) SetDeletionGracePeriodSeconds(*int64)            { panic("not implemeneted") }
+func (f *rolebinding) GetLabels() map[string]string                    { panic("not implemeneted") }
+func (f *rolebinding) SetLabels(labels map[string]string)              { panic("not implemeneted") }
+func (f *rolebinding) GetAnnotations() map[string]string               { panic("not implemeneted") }
+func (f *rolebinding) SetAnnotations(annotations map[string]string)    { panic("not implemeneted") }
+func (f *rolebinding) GetFinalizers() []string                         { panic("not implemeneted") }
+func (f *rolebinding) SetFinalizers(finalizers []string)               { panic("not implemeneted") }
+func (f *rolebinding) GetOwnerReferences() []metav1.OwnerReference     { panic("not implemeneted") }
+func (f *rolebinding) SetOwnerReferences([]metav1.OwnerReference)      { panic("not implemeneted") }
+func (f *rolebinding) GetClusterName() string                          { panic("not implemeneted") }
+func (f *rolebinding) SetClusterName(clusterName string)               { panic("not implemeneted") }
+func (f *rolebinding) GetManagedFields() []metav1.ManagedFieldsEntry   { panic("not implemeneted") }
+func (f *rolebinding) SetManagedFields(mf []metav1.ManagedFieldsEntry) { panic("not implemeneted") }
 
 func (f *rolebinding) deepCopy() *rolebinding {
 	return RoleBinding(f.target.DeepCopy())

--- a/testing/factories/secret.go
+++ b/testing/factories/secret.go
@@ -10,14 +10,13 @@ import (
 
 	rtesting "github.com/vmware-labs/reconciler-runtime/testing"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type secret struct {
+	NullObjectMeta
 	target *corev1.Secret
 }
 
@@ -42,40 +41,13 @@ func Secret(seed ...*corev1.Secret) *secret {
 	}
 }
 
-func (f *secret) DeepCopyObject() runtime.Object                  { return f.CreateObject() }
-func (f *secret) GetObjectKind() schema.ObjectKind                { return f.CreateObject().GetObjectKind() }
-func (f *secret) GetNamespace() string                            { panic("not implemeneted") }
-func (f *secret) SetNamespace(namespace string)                   { panic("not implemeneted") }
-func (f *secret) GetName() string                                 { panic("not implemeneted") }
-func (f *secret) SetName(name string)                             { panic("not implemeneted") }
-func (f *secret) GetGenerateName() string                         { panic("not implemeneted") }
-func (f *secret) SetGenerateName(name string)                     { panic("not implemeneted") }
-func (f *secret) GetUID() types.UID                               { panic("not implemeneted") }
-func (f *secret) SetUID(uid types.UID)                            { panic("not implemeneted") }
-func (f *secret) GetResourceVersion() string                      { panic("not implemeneted") }
-func (f *secret) SetResourceVersion(version string)               { panic("not implemeneted") }
-func (f *secret) GetGeneration() int64                            { panic("not implemeneted") }
-func (f *secret) SetGeneration(generation int64)                  { panic("not implemeneted") }
-func (f *secret) GetSelfLink() string                             { panic("not implemeneted") }
-func (f *secret) SetSelfLink(selfLink string)                     { panic("not implemeneted") }
-func (f *secret) GetCreationTimestamp() metav1.Time               { panic("not implemeneted") }
-func (f *secret) SetCreationTimestamp(timestamp metav1.Time)      { panic("not implemeneted") }
-func (f *secret) GetDeletionTimestamp() *metav1.Time              { panic("not implemeneted") }
-func (f *secret) SetDeletionTimestamp(timestamp *metav1.Time)     { panic("not implemeneted") }
-func (f *secret) GetDeletionGracePeriodSeconds() *int64           { panic("not implemeneted") }
-func (f *secret) SetDeletionGracePeriodSeconds(*int64)            { panic("not implemeneted") }
-func (f *secret) GetLabels() map[string]string                    { panic("not implemeneted") }
-func (f *secret) SetLabels(labels map[string]string)              { panic("not implemeneted") }
-func (f *secret) GetAnnotations() map[string]string               { panic("not implemeneted") }
-func (f *secret) SetAnnotations(annotations map[string]string)    { panic("not implemeneted") }
-func (f *secret) GetFinalizers() []string                         { panic("not implemeneted") }
-func (f *secret) SetFinalizers(finalizers []string)               { panic("not implemeneted") }
-func (f *secret) GetOwnerReferences() []metav1.OwnerReference     { panic("not implemeneted") }
-func (f *secret) SetOwnerReferences([]metav1.OwnerReference)      { panic("not implemeneted") }
-func (f *secret) GetClusterName() string                          { panic("not implemeneted") }
-func (f *secret) SetClusterName(clusterName string)               { panic("not implemeneted") }
-func (f *secret) GetManagedFields() []metav1.ManagedFieldsEntry   { panic("not implemeneted") }
-func (f *secret) SetManagedFields(mf []metav1.ManagedFieldsEntry) { panic("not implemeneted") }
+func (f *secret) DeepCopyObject() runtime.Object {
+	return f.CreateObject()
+}
+
+func (f *secret) GetObjectKind() schema.ObjectKind {
+	return f.CreateObject().GetObjectKind()
+}
 
 func (f *secret) deepCopy() *secret {
 	return Secret(f.target.DeepCopy())

--- a/testing/factories/secret.go
+++ b/testing/factories/secret.go
@@ -10,6 +10,10 @@ import (
 
 	rtesting "github.com/vmware-labs/reconciler-runtime/testing"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -19,8 +23,10 @@ type secret struct {
 
 var (
 	_ rtesting.Factory = (*secret)(nil)
+	_ client.Object    = (*secret)(nil)
 )
 
+// Deprecated
 func Secret(seed ...*corev1.Secret) *secret {
 	var target *corev1.Secret
 	switch len(seed) {
@@ -35,6 +41,41 @@ func Secret(seed ...*corev1.Secret) *secret {
 		target: target,
 	}
 }
+
+func (f *secret) DeepCopyObject() runtime.Object                  { return f.CreateObject() }
+func (f *secret) GetObjectKind() schema.ObjectKind                { return f.CreateObject().GetObjectKind() }
+func (f *secret) GetNamespace() string                            { panic("not implemeneted") }
+func (f *secret) SetNamespace(namespace string)                   { panic("not implemeneted") }
+func (f *secret) GetName() string                                 { panic("not implemeneted") }
+func (f *secret) SetName(name string)                             { panic("not implemeneted") }
+func (f *secret) GetGenerateName() string                         { panic("not implemeneted") }
+func (f *secret) SetGenerateName(name string)                     { panic("not implemeneted") }
+func (f *secret) GetUID() types.UID                               { panic("not implemeneted") }
+func (f *secret) SetUID(uid types.UID)                            { panic("not implemeneted") }
+func (f *secret) GetResourceVersion() string                      { panic("not implemeneted") }
+func (f *secret) SetResourceVersion(version string)               { panic("not implemeneted") }
+func (f *secret) GetGeneration() int64                            { panic("not implemeneted") }
+func (f *secret) SetGeneration(generation int64)                  { panic("not implemeneted") }
+func (f *secret) GetSelfLink() string                             { panic("not implemeneted") }
+func (f *secret) SetSelfLink(selfLink string)                     { panic("not implemeneted") }
+func (f *secret) GetCreationTimestamp() metav1.Time               { panic("not implemeneted") }
+func (f *secret) SetCreationTimestamp(timestamp metav1.Time)      { panic("not implemeneted") }
+func (f *secret) GetDeletionTimestamp() *metav1.Time              { panic("not implemeneted") }
+func (f *secret) SetDeletionTimestamp(timestamp *metav1.Time)     { panic("not implemeneted") }
+func (f *secret) GetDeletionGracePeriodSeconds() *int64           { panic("not implemeneted") }
+func (f *secret) SetDeletionGracePeriodSeconds(*int64)            { panic("not implemeneted") }
+func (f *secret) GetLabels() map[string]string                    { panic("not implemeneted") }
+func (f *secret) SetLabels(labels map[string]string)              { panic("not implemeneted") }
+func (f *secret) GetAnnotations() map[string]string               { panic("not implemeneted") }
+func (f *secret) SetAnnotations(annotations map[string]string)    { panic("not implemeneted") }
+func (f *secret) GetFinalizers() []string                         { panic("not implemeneted") }
+func (f *secret) SetFinalizers(finalizers []string)               { panic("not implemeneted") }
+func (f *secret) GetOwnerReferences() []metav1.OwnerReference     { panic("not implemeneted") }
+func (f *secret) SetOwnerReferences([]metav1.OwnerReference)      { panic("not implemeneted") }
+func (f *secret) GetClusterName() string                          { panic("not implemeneted") }
+func (f *secret) SetClusterName(clusterName string)               { panic("not implemeneted") }
+func (f *secret) GetManagedFields() []metav1.ManagedFieldsEntry   { panic("not implemeneted") }
+func (f *secret) SetManagedFields(mf []metav1.ManagedFieldsEntry) { panic("not implemeneted") }
 
 func (f *secret) deepCopy() *secret {
 	return Secret(f.target.DeepCopy())

--- a/testing/factories/service.go
+++ b/testing/factories/service.go
@@ -10,6 +10,10 @@ import (
 
 	rtesting "github.com/vmware-labs/reconciler-runtime/testing"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -19,8 +23,10 @@ type service struct {
 
 var (
 	_ rtesting.Factory = (*service)(nil)
+	_ client.Object    = (*service)(nil)
 )
 
+// Deprecated
 func Service(seed ...*corev1.Service) *service {
 	var target *corev1.Service
 	switch len(seed) {
@@ -35,6 +41,41 @@ func Service(seed ...*corev1.Service) *service {
 		target: target,
 	}
 }
+
+func (f *service) DeepCopyObject() runtime.Object                  { return f.CreateObject() }
+func (f *service) GetObjectKind() schema.ObjectKind                { return f.CreateObject().GetObjectKind() }
+func (f *service) GetNamespace() string                            { panic("not implemeneted") }
+func (f *service) SetNamespace(namespace string)                   { panic("not implemeneted") }
+func (f *service) GetName() string                                 { panic("not implemeneted") }
+func (f *service) SetName(name string)                             { panic("not implemeneted") }
+func (f *service) GetGenerateName() string                         { panic("not implemeneted") }
+func (f *service) SetGenerateName(name string)                     { panic("not implemeneted") }
+func (f *service) GetUID() types.UID                               { panic("not implemeneted") }
+func (f *service) SetUID(uid types.UID)                            { panic("not implemeneted") }
+func (f *service) GetResourceVersion() string                      { panic("not implemeneted") }
+func (f *service) SetResourceVersion(version string)               { panic("not implemeneted") }
+func (f *service) GetGeneration() int64                            { panic("not implemeneted") }
+func (f *service) SetGeneration(generation int64)                  { panic("not implemeneted") }
+func (f *service) GetSelfLink() string                             { panic("not implemeneted") }
+func (f *service) SetSelfLink(selfLink string)                     { panic("not implemeneted") }
+func (f *service) GetCreationTimestamp() metav1.Time               { panic("not implemeneted") }
+func (f *service) SetCreationTimestamp(timestamp metav1.Time)      { panic("not implemeneted") }
+func (f *service) GetDeletionTimestamp() *metav1.Time              { panic("not implemeneted") }
+func (f *service) SetDeletionTimestamp(timestamp *metav1.Time)     { panic("not implemeneted") }
+func (f *service) GetDeletionGracePeriodSeconds() *int64           { panic("not implemeneted") }
+func (f *service) SetDeletionGracePeriodSeconds(*int64)            { panic("not implemeneted") }
+func (f *service) GetLabels() map[string]string                    { panic("not implemeneted") }
+func (f *service) SetLabels(labels map[string]string)              { panic("not implemeneted") }
+func (f *service) GetAnnotations() map[string]string               { panic("not implemeneted") }
+func (f *service) SetAnnotations(annotations map[string]string)    { panic("not implemeneted") }
+func (f *service) GetFinalizers() []string                         { panic("not implemeneted") }
+func (f *service) SetFinalizers(finalizers []string)               { panic("not implemeneted") }
+func (f *service) GetOwnerReferences() []metav1.OwnerReference     { panic("not implemeneted") }
+func (f *service) SetOwnerReferences([]metav1.OwnerReference)      { panic("not implemeneted") }
+func (f *service) GetClusterName() string                          { panic("not implemeneted") }
+func (f *service) SetClusterName(clusterName string)               { panic("not implemeneted") }
+func (f *service) GetManagedFields() []metav1.ManagedFieldsEntry   { panic("not implemeneted") }
+func (f *service) SetManagedFields(mf []metav1.ManagedFieldsEntry) { panic("not implemeneted") }
 
 func (f *service) deepCopy() *service {
 	return Service(f.target.DeepCopy())

--- a/testing/factories/service.go
+++ b/testing/factories/service.go
@@ -10,14 +10,13 @@ import (
 
 	rtesting "github.com/vmware-labs/reconciler-runtime/testing"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type service struct {
+	NullObjectMeta
 	target *corev1.Service
 }
 
@@ -42,40 +41,13 @@ func Service(seed ...*corev1.Service) *service {
 	}
 }
 
-func (f *service) DeepCopyObject() runtime.Object                  { return f.CreateObject() }
-func (f *service) GetObjectKind() schema.ObjectKind                { return f.CreateObject().GetObjectKind() }
-func (f *service) GetNamespace() string                            { panic("not implemeneted") }
-func (f *service) SetNamespace(namespace string)                   { panic("not implemeneted") }
-func (f *service) GetName() string                                 { panic("not implemeneted") }
-func (f *service) SetName(name string)                             { panic("not implemeneted") }
-func (f *service) GetGenerateName() string                         { panic("not implemeneted") }
-func (f *service) SetGenerateName(name string)                     { panic("not implemeneted") }
-func (f *service) GetUID() types.UID                               { panic("not implemeneted") }
-func (f *service) SetUID(uid types.UID)                            { panic("not implemeneted") }
-func (f *service) GetResourceVersion() string                      { panic("not implemeneted") }
-func (f *service) SetResourceVersion(version string)               { panic("not implemeneted") }
-func (f *service) GetGeneration() int64                            { panic("not implemeneted") }
-func (f *service) SetGeneration(generation int64)                  { panic("not implemeneted") }
-func (f *service) GetSelfLink() string                             { panic("not implemeneted") }
-func (f *service) SetSelfLink(selfLink string)                     { panic("not implemeneted") }
-func (f *service) GetCreationTimestamp() metav1.Time               { panic("not implemeneted") }
-func (f *service) SetCreationTimestamp(timestamp metav1.Time)      { panic("not implemeneted") }
-func (f *service) GetDeletionTimestamp() *metav1.Time              { panic("not implemeneted") }
-func (f *service) SetDeletionTimestamp(timestamp *metav1.Time)     { panic("not implemeneted") }
-func (f *service) GetDeletionGracePeriodSeconds() *int64           { panic("not implemeneted") }
-func (f *service) SetDeletionGracePeriodSeconds(*int64)            { panic("not implemeneted") }
-func (f *service) GetLabels() map[string]string                    { panic("not implemeneted") }
-func (f *service) SetLabels(labels map[string]string)              { panic("not implemeneted") }
-func (f *service) GetAnnotations() map[string]string               { panic("not implemeneted") }
-func (f *service) SetAnnotations(annotations map[string]string)    { panic("not implemeneted") }
-func (f *service) GetFinalizers() []string                         { panic("not implemeneted") }
-func (f *service) SetFinalizers(finalizers []string)               { panic("not implemeneted") }
-func (f *service) GetOwnerReferences() []metav1.OwnerReference     { panic("not implemeneted") }
-func (f *service) SetOwnerReferences([]metav1.OwnerReference)      { panic("not implemeneted") }
-func (f *service) GetClusterName() string                          { panic("not implemeneted") }
-func (f *service) SetClusterName(clusterName string)               { panic("not implemeneted") }
-func (f *service) GetManagedFields() []metav1.ManagedFieldsEntry   { panic("not implemeneted") }
-func (f *service) SetManagedFields(mf []metav1.ManagedFieldsEntry) { panic("not implemeneted") }
+func (f *service) DeepCopyObject() runtime.Object {
+	return f.CreateObject()
+}
+
+func (f *service) GetObjectKind() schema.ObjectKind {
+	return f.CreateObject().GetObjectKind()
+}
 
 func (f *service) deepCopy() *service {
 	return Service(f.target.DeepCopy())

--- a/testing/factories/serviceaccount.go
+++ b/testing/factories/serviceaccount.go
@@ -10,14 +10,13 @@ import (
 
 	rtesting "github.com/vmware-labs/reconciler-runtime/testing"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type serviceAccount struct {
+	NullObjectMeta
 	target *corev1.ServiceAccount
 }
 
@@ -42,40 +41,13 @@ func ServiceAccount(seed ...*corev1.ServiceAccount) *serviceAccount {
 	}
 }
 
-func (f *serviceAccount) DeepCopyObject() runtime.Object                  { return f.CreateObject() }
-func (f *serviceAccount) GetObjectKind() schema.ObjectKind                { return f.CreateObject().GetObjectKind() }
-func (f *serviceAccount) GetNamespace() string                            { panic("not implemeneted") }
-func (f *serviceAccount) SetNamespace(namespace string)                   { panic("not implemeneted") }
-func (f *serviceAccount) GetName() string                                 { panic("not implemeneted") }
-func (f *serviceAccount) SetName(name string)                             { panic("not implemeneted") }
-func (f *serviceAccount) GetGenerateName() string                         { panic("not implemeneted") }
-func (f *serviceAccount) SetGenerateName(name string)                     { panic("not implemeneted") }
-func (f *serviceAccount) GetUID() types.UID                               { panic("not implemeneted") }
-func (f *serviceAccount) SetUID(uid types.UID)                            { panic("not implemeneted") }
-func (f *serviceAccount) GetResourceVersion() string                      { panic("not implemeneted") }
-func (f *serviceAccount) SetResourceVersion(version string)               { panic("not implemeneted") }
-func (f *serviceAccount) GetGeneration() int64                            { panic("not implemeneted") }
-func (f *serviceAccount) SetGeneration(generation int64)                  { panic("not implemeneted") }
-func (f *serviceAccount) GetSelfLink() string                             { panic("not implemeneted") }
-func (f *serviceAccount) SetSelfLink(selfLink string)                     { panic("not implemeneted") }
-func (f *serviceAccount) GetCreationTimestamp() metav1.Time               { panic("not implemeneted") }
-func (f *serviceAccount) SetCreationTimestamp(timestamp metav1.Time)      { panic("not implemeneted") }
-func (f *serviceAccount) GetDeletionTimestamp() *metav1.Time              { panic("not implemeneted") }
-func (f *serviceAccount) SetDeletionTimestamp(timestamp *metav1.Time)     { panic("not implemeneted") }
-func (f *serviceAccount) GetDeletionGracePeriodSeconds() *int64           { panic("not implemeneted") }
-func (f *serviceAccount) SetDeletionGracePeriodSeconds(*int64)            { panic("not implemeneted") }
-func (f *serviceAccount) GetLabels() map[string]string                    { panic("not implemeneted") }
-func (f *serviceAccount) SetLabels(labels map[string]string)              { panic("not implemeneted") }
-func (f *serviceAccount) GetAnnotations() map[string]string               { panic("not implemeneted") }
-func (f *serviceAccount) SetAnnotations(annotations map[string]string)    { panic("not implemeneted") }
-func (f *serviceAccount) GetFinalizers() []string                         { panic("not implemeneted") }
-func (f *serviceAccount) SetFinalizers(finalizers []string)               { panic("not implemeneted") }
-func (f *serviceAccount) GetOwnerReferences() []metav1.OwnerReference     { panic("not implemeneted") }
-func (f *serviceAccount) SetOwnerReferences([]metav1.OwnerReference)      { panic("not implemeneted") }
-func (f *serviceAccount) GetClusterName() string                          { panic("not implemeneted") }
-func (f *serviceAccount) SetClusterName(clusterName string)               { panic("not implemeneted") }
-func (f *serviceAccount) GetManagedFields() []metav1.ManagedFieldsEntry   { panic("not implemeneted") }
-func (f *serviceAccount) SetManagedFields(mf []metav1.ManagedFieldsEntry) { panic("not implemeneted") }
+func (f *serviceAccount) DeepCopyObject() runtime.Object {
+	return f.CreateObject()
+}
+
+func (f *serviceAccount) GetObjectKind() schema.ObjectKind {
+	return f.CreateObject().GetObjectKind()
+}
 
 func (f *serviceAccount) deepCopy() *serviceAccount {
 	return ServiceAccount(f.target.DeepCopy())

--- a/testing/factories/serviceaccount.go
+++ b/testing/factories/serviceaccount.go
@@ -10,6 +10,10 @@ import (
 
 	rtesting "github.com/vmware-labs/reconciler-runtime/testing"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -19,8 +23,10 @@ type serviceAccount struct {
 
 var (
 	_ rtesting.Factory = (*serviceAccount)(nil)
+	_ client.Object    = (*serviceAccount)(nil)
 )
 
+// Deprecated
 func ServiceAccount(seed ...*corev1.ServiceAccount) *serviceAccount {
 	var target *corev1.ServiceAccount
 	switch len(seed) {
@@ -35,6 +41,41 @@ func ServiceAccount(seed ...*corev1.ServiceAccount) *serviceAccount {
 		target: target,
 	}
 }
+
+func (f *serviceAccount) DeepCopyObject() runtime.Object                  { return f.CreateObject() }
+func (f *serviceAccount) GetObjectKind() schema.ObjectKind                { return f.CreateObject().GetObjectKind() }
+func (f *serviceAccount) GetNamespace() string                            { panic("not implemeneted") }
+func (f *serviceAccount) SetNamespace(namespace string)                   { panic("not implemeneted") }
+func (f *serviceAccount) GetName() string                                 { panic("not implemeneted") }
+func (f *serviceAccount) SetName(name string)                             { panic("not implemeneted") }
+func (f *serviceAccount) GetGenerateName() string                         { panic("not implemeneted") }
+func (f *serviceAccount) SetGenerateName(name string)                     { panic("not implemeneted") }
+func (f *serviceAccount) GetUID() types.UID                               { panic("not implemeneted") }
+func (f *serviceAccount) SetUID(uid types.UID)                            { panic("not implemeneted") }
+func (f *serviceAccount) GetResourceVersion() string                      { panic("not implemeneted") }
+func (f *serviceAccount) SetResourceVersion(version string)               { panic("not implemeneted") }
+func (f *serviceAccount) GetGeneration() int64                            { panic("not implemeneted") }
+func (f *serviceAccount) SetGeneration(generation int64)                  { panic("not implemeneted") }
+func (f *serviceAccount) GetSelfLink() string                             { panic("not implemeneted") }
+func (f *serviceAccount) SetSelfLink(selfLink string)                     { panic("not implemeneted") }
+func (f *serviceAccount) GetCreationTimestamp() metav1.Time               { panic("not implemeneted") }
+func (f *serviceAccount) SetCreationTimestamp(timestamp metav1.Time)      { panic("not implemeneted") }
+func (f *serviceAccount) GetDeletionTimestamp() *metav1.Time              { panic("not implemeneted") }
+func (f *serviceAccount) SetDeletionTimestamp(timestamp *metav1.Time)     { panic("not implemeneted") }
+func (f *serviceAccount) GetDeletionGracePeriodSeconds() *int64           { panic("not implemeneted") }
+func (f *serviceAccount) SetDeletionGracePeriodSeconds(*int64)            { panic("not implemeneted") }
+func (f *serviceAccount) GetLabels() map[string]string                    { panic("not implemeneted") }
+func (f *serviceAccount) SetLabels(labels map[string]string)              { panic("not implemeneted") }
+func (f *serviceAccount) GetAnnotations() map[string]string               { panic("not implemeneted") }
+func (f *serviceAccount) SetAnnotations(annotations map[string]string)    { panic("not implemeneted") }
+func (f *serviceAccount) GetFinalizers() []string                         { panic("not implemeneted") }
+func (f *serviceAccount) SetFinalizers(finalizers []string)               { panic("not implemeneted") }
+func (f *serviceAccount) GetOwnerReferences() []metav1.OwnerReference     { panic("not implemeneted") }
+func (f *serviceAccount) SetOwnerReferences([]metav1.OwnerReference)      { panic("not implemeneted") }
+func (f *serviceAccount) GetClusterName() string                          { panic("not implemeneted") }
+func (f *serviceAccount) SetClusterName(clusterName string)               { panic("not implemeneted") }
+func (f *serviceAccount) GetManagedFields() []metav1.ManagedFieldsEntry   { panic("not implemeneted") }
+func (f *serviceAccount) SetManagedFields(mf []metav1.ManagedFieldsEntry) { panic("not implemeneted") }
 
 func (f *serviceAccount) deepCopy() *serviceAccount {
 	return ServiceAccount(f.target.DeepCopy())

--- a/testing/factories/testresource.go
+++ b/testing/factories/testresource.go
@@ -10,14 +10,13 @@ import (
 
 	"github.com/vmware-labs/reconciler-runtime/apis"
 	rtesting "github.com/vmware-labs/reconciler-runtime/testing"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type testresource struct {
+	NullObjectMeta
 	target *rtesting.TestResource
 }
 
@@ -42,40 +41,13 @@ func TestResource(seed ...*rtesting.TestResource) *testresource {
 	}
 }
 
-func (f *testresource) DeepCopyObject() runtime.Object                  { return f.CreateObject() }
-func (f *testresource) GetObjectKind() schema.ObjectKind                { return f.CreateObject().GetObjectKind() }
-func (f *testresource) GetNamespace() string                            { panic("not implemeneted") }
-func (f *testresource) SetNamespace(namespace string)                   { panic("not implemeneted") }
-func (f *testresource) GetName() string                                 { panic("not implemeneted") }
-func (f *testresource) SetName(name string)                             { panic("not implemeneted") }
-func (f *testresource) GetGenerateName() string                         { panic("not implemeneted") }
-func (f *testresource) SetGenerateName(name string)                     { panic("not implemeneted") }
-func (f *testresource) GetUID() types.UID                               { panic("not implemeneted") }
-func (f *testresource) SetUID(uid types.UID)                            { panic("not implemeneted") }
-func (f *testresource) GetResourceVersion() string                      { panic("not implemeneted") }
-func (f *testresource) SetResourceVersion(version string)               { panic("not implemeneted") }
-func (f *testresource) GetGeneration() int64                            { panic("not implemeneted") }
-func (f *testresource) SetGeneration(generation int64)                  { panic("not implemeneted") }
-func (f *testresource) GetSelfLink() string                             { panic("not implemeneted") }
-func (f *testresource) SetSelfLink(selfLink string)                     { panic("not implemeneted") }
-func (f *testresource) GetCreationTimestamp() metav1.Time               { panic("not implemeneted") }
-func (f *testresource) SetCreationTimestamp(timestamp metav1.Time)      { panic("not implemeneted") }
-func (f *testresource) GetDeletionTimestamp() *metav1.Time              { panic("not implemeneted") }
-func (f *testresource) SetDeletionTimestamp(timestamp *metav1.Time)     { panic("not implemeneted") }
-func (f *testresource) GetDeletionGracePeriodSeconds() *int64           { panic("not implemeneted") }
-func (f *testresource) SetDeletionGracePeriodSeconds(*int64)            { panic("not implemeneted") }
-func (f *testresource) GetLabels() map[string]string                    { panic("not implemeneted") }
-func (f *testresource) SetLabels(labels map[string]string)              { panic("not implemeneted") }
-func (f *testresource) GetAnnotations() map[string]string               { panic("not implemeneted") }
-func (f *testresource) SetAnnotations(annotations map[string]string)    { panic("not implemeneted") }
-func (f *testresource) GetFinalizers() []string                         { panic("not implemeneted") }
-func (f *testresource) SetFinalizers(finalizers []string)               { panic("not implemeneted") }
-func (f *testresource) GetOwnerReferences() []metav1.OwnerReference     { panic("not implemeneted") }
-func (f *testresource) SetOwnerReferences([]metav1.OwnerReference)      { panic("not implemeneted") }
-func (f *testresource) GetClusterName() string                          { panic("not implemeneted") }
-func (f *testresource) SetClusterName(clusterName string)               { panic("not implemeneted") }
-func (f *testresource) GetManagedFields() []metav1.ManagedFieldsEntry   { panic("not implemeneted") }
-func (f *testresource) SetManagedFields(mf []metav1.ManagedFieldsEntry) { panic("not implemeneted") }
+func (f *testresource) DeepCopyObject() runtime.Object {
+	return f.CreateObject()
+}
+
+func (f *testresource) GetObjectKind() schema.ObjectKind {
+	return f.CreateObject().GetObjectKind()
+}
 
 func (f *testresource) deepCopy() *testresource {
 	return TestResource(f.target.DeepCopy())

--- a/testing/factories/testresource.go
+++ b/testing/factories/testresource.go
@@ -10,6 +10,10 @@ import (
 
 	"github.com/vmware-labs/reconciler-runtime/apis"
 	rtesting "github.com/vmware-labs/reconciler-runtime/testing"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -19,8 +23,10 @@ type testresource struct {
 
 var (
 	_ rtesting.Factory = (*testresource)(nil)
+	_ client.Object    = (*testresource)(nil)
 )
 
+// Deprecated
 func TestResource(seed ...*rtesting.TestResource) *testresource {
 	var target *rtesting.TestResource
 	switch len(seed) {
@@ -35,6 +41,41 @@ func TestResource(seed ...*rtesting.TestResource) *testresource {
 		target: target,
 	}
 }
+
+func (f *testresource) DeepCopyObject() runtime.Object                  { return f.CreateObject() }
+func (f *testresource) GetObjectKind() schema.ObjectKind                { return f.CreateObject().GetObjectKind() }
+func (f *testresource) GetNamespace() string                            { panic("not implemeneted") }
+func (f *testresource) SetNamespace(namespace string)                   { panic("not implemeneted") }
+func (f *testresource) GetName() string                                 { panic("not implemeneted") }
+func (f *testresource) SetName(name string)                             { panic("not implemeneted") }
+func (f *testresource) GetGenerateName() string                         { panic("not implemeneted") }
+func (f *testresource) SetGenerateName(name string)                     { panic("not implemeneted") }
+func (f *testresource) GetUID() types.UID                               { panic("not implemeneted") }
+func (f *testresource) SetUID(uid types.UID)                            { panic("not implemeneted") }
+func (f *testresource) GetResourceVersion() string                      { panic("not implemeneted") }
+func (f *testresource) SetResourceVersion(version string)               { panic("not implemeneted") }
+func (f *testresource) GetGeneration() int64                            { panic("not implemeneted") }
+func (f *testresource) SetGeneration(generation int64)                  { panic("not implemeneted") }
+func (f *testresource) GetSelfLink() string                             { panic("not implemeneted") }
+func (f *testresource) SetSelfLink(selfLink string)                     { panic("not implemeneted") }
+func (f *testresource) GetCreationTimestamp() metav1.Time               { panic("not implemeneted") }
+func (f *testresource) SetCreationTimestamp(timestamp metav1.Time)      { panic("not implemeneted") }
+func (f *testresource) GetDeletionTimestamp() *metav1.Time              { panic("not implemeneted") }
+func (f *testresource) SetDeletionTimestamp(timestamp *metav1.Time)     { panic("not implemeneted") }
+func (f *testresource) GetDeletionGracePeriodSeconds() *int64           { panic("not implemeneted") }
+func (f *testresource) SetDeletionGracePeriodSeconds(*int64)            { panic("not implemeneted") }
+func (f *testresource) GetLabels() map[string]string                    { panic("not implemeneted") }
+func (f *testresource) SetLabels(labels map[string]string)              { panic("not implemeneted") }
+func (f *testresource) GetAnnotations() map[string]string               { panic("not implemeneted") }
+func (f *testresource) SetAnnotations(annotations map[string]string)    { panic("not implemeneted") }
+func (f *testresource) GetFinalizers() []string                         { panic("not implemeneted") }
+func (f *testresource) SetFinalizers(finalizers []string)               { panic("not implemeneted") }
+func (f *testresource) GetOwnerReferences() []metav1.OwnerReference     { panic("not implemeneted") }
+func (f *testresource) SetOwnerReferences([]metav1.OwnerReference)      { panic("not implemeneted") }
+func (f *testresource) GetClusterName() string                          { panic("not implemeneted") }
+func (f *testresource) SetClusterName(clusterName string)               { panic("not implemeneted") }
+func (f *testresource) GetManagedFields() []metav1.ManagedFieldsEntry   { panic("not implemeneted") }
+func (f *testresource) SetManagedFields(mf []metav1.ManagedFieldsEntry) { panic("not implemeneted") }
 
 func (f *testresource) deepCopy() *testresource {
 	return TestResource(f.target.DeepCopy())

--- a/testing/factories/testresource_without_status.go
+++ b/testing/factories/testresource_without_status.go
@@ -9,6 +9,10 @@ import (
 	"fmt"
 
 	rtesting "github.com/vmware-labs/reconciler-runtime/testing"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -18,8 +22,10 @@ type testresourcenostatus struct {
 
 var (
 	_ rtesting.Factory = (*testresourcenostatus)(nil)
+	_ client.Object    = (*testresourcenostatus)(nil)
 )
 
+// Deprecated
 func TestResourceNoStatus(seed ...*rtesting.TestResourceNoStatus) *testresourcenostatus {
 	var target *rtesting.TestResourceNoStatus
 	switch len(seed) {
@@ -33,6 +39,53 @@ func TestResourceNoStatus(seed ...*rtesting.TestResourceNoStatus) *testresourcen
 	return &testresourcenostatus{
 		target: target,
 	}
+}
+
+func (f *testresourcenostatus) DeepCopyObject() runtime.Object { return f.CreateObject() }
+func (f *testresourcenostatus) GetObjectKind() schema.ObjectKind {
+	return f.CreateObject().GetObjectKind()
+}
+func (f *testresourcenostatus) GetNamespace() string                       { panic("not implemeneted") }
+func (f *testresourcenostatus) SetNamespace(namespace string)              { panic("not implemeneted") }
+func (f *testresourcenostatus) GetName() string                            { panic("not implemeneted") }
+func (f *testresourcenostatus) SetName(name string)                        { panic("not implemeneted") }
+func (f *testresourcenostatus) GetGenerateName() string                    { panic("not implemeneted") }
+func (f *testresourcenostatus) SetGenerateName(name string)                { panic("not implemeneted") }
+func (f *testresourcenostatus) GetUID() types.UID                          { panic("not implemeneted") }
+func (f *testresourcenostatus) SetUID(uid types.UID)                       { panic("not implemeneted") }
+func (f *testresourcenostatus) GetResourceVersion() string                 { panic("not implemeneted") }
+func (f *testresourcenostatus) SetResourceVersion(version string)          { panic("not implemeneted") }
+func (f *testresourcenostatus) GetGeneration() int64                       { panic("not implemeneted") }
+func (f *testresourcenostatus) SetGeneration(generation int64)             { panic("not implemeneted") }
+func (f *testresourcenostatus) GetSelfLink() string                        { panic("not implemeneted") }
+func (f *testresourcenostatus) SetSelfLink(selfLink string)                { panic("not implemeneted") }
+func (f *testresourcenostatus) GetCreationTimestamp() metav1.Time          { panic("not implemeneted") }
+func (f *testresourcenostatus) SetCreationTimestamp(timestamp metav1.Time) { panic("not implemeneted") }
+func (f *testresourcenostatus) GetDeletionTimestamp() *metav1.Time         { panic("not implemeneted") }
+func (f *testresourcenostatus) SetDeletionTimestamp(timestamp *metav1.Time) {
+	panic("not implemeneted")
+}
+func (f *testresourcenostatus) GetDeletionGracePeriodSeconds() *int64 { panic("not implemeneted") }
+func (f *testresourcenostatus) SetDeletionGracePeriodSeconds(*int64)  { panic("not implemeneted") }
+func (f *testresourcenostatus) GetLabels() map[string]string          { panic("not implemeneted") }
+func (f *testresourcenostatus) SetLabels(labels map[string]string)    { panic("not implemeneted") }
+func (f *testresourcenostatus) GetAnnotations() map[string]string     { panic("not implemeneted") }
+func (f *testresourcenostatus) SetAnnotations(annotations map[string]string) {
+	panic("not implemeneted")
+}
+func (f *testresourcenostatus) GetFinalizers() []string           { panic("not implemeneted") }
+func (f *testresourcenostatus) SetFinalizers(finalizers []string) { panic("not implemeneted") }
+func (f *testresourcenostatus) GetOwnerReferences() []metav1.OwnerReference {
+	panic("not implemeneted")
+}
+func (f *testresourcenostatus) SetOwnerReferences([]metav1.OwnerReference) { panic("not implemeneted") }
+func (f *testresourcenostatus) GetClusterName() string                     { panic("not implemeneted") }
+func (f *testresourcenostatus) SetClusterName(clusterName string)          { panic("not implemeneted") }
+func (f *testresourcenostatus) GetManagedFields() []metav1.ManagedFieldsEntry {
+	panic("not implemeneted")
+}
+func (f *testresourcenostatus) SetManagedFields(mf []metav1.ManagedFieldsEntry) {
+	panic("not implemeneted")
 }
 
 func (f *testresourcenostatus) deepCopy() *testresourcenostatus {

--- a/testing/factories/testresource_without_status.go
+++ b/testing/factories/testresource_without_status.go
@@ -9,14 +9,13 @@ import (
 	"fmt"
 
 	rtesting "github.com/vmware-labs/reconciler-runtime/testing"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type testresourcenostatus struct {
+	NullObjectMeta
 	target *rtesting.TestResourceNoStatus
 }
 
@@ -41,51 +40,12 @@ func TestResourceNoStatus(seed ...*rtesting.TestResourceNoStatus) *testresourcen
 	}
 }
 
-func (f *testresourcenostatus) DeepCopyObject() runtime.Object { return f.CreateObject() }
+func (f *testresourcenostatus) DeepCopyObject() runtime.Object {
+	return f.CreateObject()
+}
+
 func (f *testresourcenostatus) GetObjectKind() schema.ObjectKind {
 	return f.CreateObject().GetObjectKind()
-}
-func (f *testresourcenostatus) GetNamespace() string                       { panic("not implemeneted") }
-func (f *testresourcenostatus) SetNamespace(namespace string)              { panic("not implemeneted") }
-func (f *testresourcenostatus) GetName() string                            { panic("not implemeneted") }
-func (f *testresourcenostatus) SetName(name string)                        { panic("not implemeneted") }
-func (f *testresourcenostatus) GetGenerateName() string                    { panic("not implemeneted") }
-func (f *testresourcenostatus) SetGenerateName(name string)                { panic("not implemeneted") }
-func (f *testresourcenostatus) GetUID() types.UID                          { panic("not implemeneted") }
-func (f *testresourcenostatus) SetUID(uid types.UID)                       { panic("not implemeneted") }
-func (f *testresourcenostatus) GetResourceVersion() string                 { panic("not implemeneted") }
-func (f *testresourcenostatus) SetResourceVersion(version string)          { panic("not implemeneted") }
-func (f *testresourcenostatus) GetGeneration() int64                       { panic("not implemeneted") }
-func (f *testresourcenostatus) SetGeneration(generation int64)             { panic("not implemeneted") }
-func (f *testresourcenostatus) GetSelfLink() string                        { panic("not implemeneted") }
-func (f *testresourcenostatus) SetSelfLink(selfLink string)                { panic("not implemeneted") }
-func (f *testresourcenostatus) GetCreationTimestamp() metav1.Time          { panic("not implemeneted") }
-func (f *testresourcenostatus) SetCreationTimestamp(timestamp metav1.Time) { panic("not implemeneted") }
-func (f *testresourcenostatus) GetDeletionTimestamp() *metav1.Time         { panic("not implemeneted") }
-func (f *testresourcenostatus) SetDeletionTimestamp(timestamp *metav1.Time) {
-	panic("not implemeneted")
-}
-func (f *testresourcenostatus) GetDeletionGracePeriodSeconds() *int64 { panic("not implemeneted") }
-func (f *testresourcenostatus) SetDeletionGracePeriodSeconds(*int64)  { panic("not implemeneted") }
-func (f *testresourcenostatus) GetLabels() map[string]string          { panic("not implemeneted") }
-func (f *testresourcenostatus) SetLabels(labels map[string]string)    { panic("not implemeneted") }
-func (f *testresourcenostatus) GetAnnotations() map[string]string     { panic("not implemeneted") }
-func (f *testresourcenostatus) SetAnnotations(annotations map[string]string) {
-	panic("not implemeneted")
-}
-func (f *testresourcenostatus) GetFinalizers() []string           { panic("not implemeneted") }
-func (f *testresourcenostatus) SetFinalizers(finalizers []string) { panic("not implemeneted") }
-func (f *testresourcenostatus) GetOwnerReferences() []metav1.OwnerReference {
-	panic("not implemeneted")
-}
-func (f *testresourcenostatus) SetOwnerReferences([]metav1.OwnerReference) { panic("not implemeneted") }
-func (f *testresourcenostatus) GetClusterName() string                     { panic("not implemeneted") }
-func (f *testresourcenostatus) SetClusterName(clusterName string)          { panic("not implemeneted") }
-func (f *testresourcenostatus) GetManagedFields() []metav1.ManagedFieldsEntry {
-	panic("not implemeneted")
-}
-func (f *testresourcenostatus) SetManagedFields(mf []metav1.ManagedFieldsEntry) {
-	panic("not implemeneted")
 }
 
 func (f *testresourcenostatus) deepCopy() *testresourcenostatus {

--- a/testing/factory.go
+++ b/testing/factory.go
@@ -9,12 +9,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// Factory creates Kubernetes objects
+// Deprecated Factory creates Kubernetes objects
 type Factory interface {
 	// CreateObject creates a new Kubernetes object
 	CreateObject() client.Object
 }
 
+// Deprecated
 func Wrapper(obj client.Object) Factory {
 	return &wrapper{obj: obj}
 }

--- a/testing/recorder.go
+++ b/testing/recorder.go
@@ -23,8 +23,8 @@ type Event struct {
 	Message string
 }
 
-func NewEvent(factory Factory, scheme *runtime.Scheme, eventtype, reason, messageFormat string, a ...interface{}) Event {
-	obj := factory.CreateObject()
+func NewEvent(factory client.Object, scheme *runtime.Scheme, eventtype, reason, messageFormat string, a ...interface{}) Event {
+	obj := factory.DeepCopyObject().(client.Object)
 	gvks, _, _ := scheme.ObjectKinds(obj)
 	apiVersion, kind := gvks[0].ToAPIVersionAndKind()
 

--- a/testing/tracker.go
+++ b/testing/tracker.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // TrackRequest records that one object is tracking another object.
@@ -38,8 +39,8 @@ func CreateTrackRequest(trackedObjGroup, trackedObjKind, trackedObjNamespace, tr
 	}
 }
 
-func NewTrackRequest(t, b Factory, scheme *runtime.Scheme) TrackRequest {
-	tracked, by := t.CreateObject(), b.CreateObject()
+func NewTrackRequest(t, b client.Object, scheme *runtime.Scheme) TrackRequest {
+	tracked, by := t.DeepCopyObject().(client.Object), b.DeepCopyObject().(client.Object)
 	gvks, _, err := scheme.ObjectKinds(tracked)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
The resource factories defined as part of reconciler-runtime covered a
very small percent of the Kubernetes API surface and are too hard to
create for general purpose. New tooling like https://dies.dev
spiritually cover the same concepts with much higher API coverage and
offer the ability to cover user defined resources.

In practice, everywhere a `rtesting.Factory` was accepted now accepts a
`client.Object` instead. The existing factories have been updated to
implement the `client.Object` interface as a migration bridge, but will
be removed in a future release.

Users who do not want to adopt a third-party tools like dies may either
define full resources (e.g. `appsv1.Deployment`) or create types that
also implement the `client.Object` interface. Internally, reconciler
runtime will call the `.DeepCopyObject()` method before any use
providing an equivalent behavior to `rtesting.Factory` in a more
compatible interface.

Refs #160 