### PR TITLE
Switch codecov to informational mode

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,7 @@
+ignore:
+  - "**/zz_generated.*.go"
+coverage:
+  status:
+    project:
+      default:
+        informational: true


### PR DESCRIPTION
Codecov will still track and report coverage for PRs, but will not vote.

Signed-off-by: Scott Andrews <andrewssc@vmware.com>