### PR TITLE
Describe the status contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The [`SyncReconciler`](https://pkg.go.dev/github.com/vmware-labs/reconciler-runt
 
 **Example:**
 
-While sync reconcilers have the ability to do anything a reconciler can do, it's best to keep them focused on a single goal, letting the parent reconciler structure multiple sub reconcilers together. In this case, we use the parent resource and the client to resolve the target image and stash the value on the parent's status. The status is a good place to stash simple values that can be made public. More [advanced forms of stashing](#stash) are also available.
+While sync reconcilers have the ability to do anything a reconciler can do, it's best to keep them focused on a single goal, letting the parent reconciler structure multiple sub reconcilers together. In this case, we use the parent resource and the client to resolve the target image and stash the value on the parent's status. The status is a good place to stash simple values that can be made public. More [advanced forms of stashing](#stash) are also available. Learn more about [status and its contract](#status).
 
 ```go
 func FunctionTargetImageReconciler(c reconcilers.Config) reconcilers.SubReconciler {
@@ -116,6 +116,7 @@ The implementor is responsible for:
 - indicating if two resources are semantically equal
 - merging the actual resource with the desired state (often as simple as copying the spec and labels)
 - updating the parent's status from the child
+- defining the status subresource [according to the contract](#status) 
 
 **Example:**
 
@@ -467,6 +468,50 @@ func InMemoryGatewaySyncConfigReconciler(c reconcilers.Config, namespace string)
 }
 ```
 [full source](https://github.com/projectriff/system/blob/4c3b75327bf99cc37b57ba14df4c65d21dc79d28/pkg/controllers/streaming/inmemorygateway_reconciler.go#L58-L84)
+
+### Status
+
+The `apis` package provides means for conveniently managing a custom resource's `.status`.
+
+A resource's status subresource is expected to meet the following contract:
+
+```go
+type MyStatus struct {
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
+}
+```
+
+**Example:**
+
+Use `api.Status` as your resource's status:
+
+```go
+type MyResource struct {
+  metav1.TypeMeta   `json:",inline"`
+  metav1.ObjectMeta `json:"metadata,omitempty"`
+  
+  Spec MyResourceSpec `json:"spec"`
+  Status apis.Status `json:,inline"`
+}
+```
+
+Inline `api.Status` into your resource's status to add more fields:
+
+```go
+type MyResourceStatus struct {
+  apis.Status `json:,inline"`
+  UsefulMessage string `json:"usefulMessage,omitempty"`
+}
+
+type MyResource struct {
+  metav1.TypeMeta   `json:",inline"`
+  metav1.ObjectMeta `json:"metadata,omitempty"`
+  
+  Spec MyResourceSpec `json:"spec,omitempty"`
+  Status MyResourceStatus `json:status,omitempty"`
+}
+```
 
 ## Contributing
 

--- a/apis/status_types.go
+++ b/apis/status_types.go
@@ -22,8 +22,21 @@ package apis
 
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-// Status shows how we expect folks to embed Conditions in
-// their Status field.
+// Status is the minimally expected status subresource. Use this or provide your own. It also shows how Conditions are
+// expected to be embedded in the Status field.
+//
+// Example: Inline it as is into your resource
+//   type MyResource struct {
+//   	// ...
+//   	Status apis.Status `json:,inline"`
+//   }
+//
+// Example: Inline it into your custom subresource and extend
+//   type MyResourceStatus struct {
+//   	apis.Status `json:,inline"`
+//   	UsefulMessage string `json:"usefulMessage,omitempty"`
+//   }
+//
 // WARNING: Adding fields to this struct will add them to all resources.
 // +k8s:deepcopy-gen=true
 type Status struct {


### PR DESCRIPTION
Since it's not immediately clear how `reconciler-runtime` expects a resource's `.status` to look like, I thought I'd propose this for the `README.md` and `api.Status`'s doc comment.