### PR TITLE
Optional finalize for parent reconciler

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,11 @@ The parent is responsible for:
 - updates the resource status if it was modified
 - logging the reconcilers activities
 - records events for mutations and errors
+- adding and removing a finalizer if needed
 
 The implementor is responsible for:
 - defining the set of sub reconcilers
+- providing instructions on how to clean up on deletion if needed
 
 **Example:**
 

--- a/reconcilers/reconcilers.go
+++ b/reconcilers/reconcilers.go
@@ -177,10 +177,10 @@ func (r *ParentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		if updateErr := r.Update(ctx, parent); updateErr != nil {
 			log.Error(updateErr, "unable to update", typeName(r.Type), parent)
 			r.Recorder.Eventf(parent, corev1.EventTypeWarning, "UpdateFailed",
-				"Failed to update: %v", updateErr)
+				"Failed to update finalizers: %v", updateErr)
 			return ctrl.Result{}, updateErr
 		}
-		r.Recorder.Eventf(parent, corev1.EventTypeNormal, "Updated", "Updated")
+		r.Recorder.Eventf(parent, corev1.EventTypeNormal, "Updated", "Updated finalizers")
 	}
 
 	// return original reconcile result
@@ -188,7 +188,7 @@ func (r *ParentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 }
 
 func (r *ParentReconciler) reconcile(ctx context.Context, parent client.Object) (ctrl.Result, error) {
-	finalizer := fmt.Sprintf("%s/reconciler-runtime-finalize", parent.GetObjectKind().GroupVersionKind().Group)
+	finalizer := fmt.Sprintf("%s/reconciler-runtime-finalizer", parent.GetObjectKind().GroupVersionKind().Group)
 	if r.Finalize == nil {
 		controllerutil.RemoveFinalizer(parent, finalizer)
 	} else {

--- a/reconcilers/reconcilers_test.go
+++ b/reconcilers/reconcilers_test.go
@@ -95,7 +95,7 @@ func TestParentReconciler(t *testing.T) {
 			)
 		})
 	deletedAt := metav1.NewTime(time.UnixMilli(2000))
-	const finalizer = "testing.reconciler.runtime/reconciler-runtime-finalize"
+	const finalizer = "testing.reconciler.runtime/reconciler-runtime-finalizer"
 
 	rts := rtesting.ReconcilerTestSuite{{
 		Name: "resource does not exist",
@@ -317,7 +317,7 @@ func TestParentReconciler(t *testing.T) {
 			}),
 		},
 		ExpectEvents: []rtesting.Event{
-			rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Updated", `Updated`),
+			rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Updated", `Updated finalizers`),
 		},
 		Metadata: map[string]interface{}{
 			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
@@ -343,7 +343,7 @@ func TestParentReconciler(t *testing.T) {
 			}),
 		},
 		ExpectEvents: []rtesting.Event{
-			rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Updated", `Updated`),
+			rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Updated", `Updated finalizers`),
 		},
 		Metadata: map[string]interface{}{
 			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
@@ -376,7 +376,7 @@ func TestParentReconciler(t *testing.T) {
 			}),
 		},
 		ExpectEvents: []rtesting.Event{
-			rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Updated", `Updated`),
+			rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Updated", `Updated finalizers`),
 		},
 		ExpectUpdates: []client.Object{
 			resource.MetadataDie(func(d *diemetav1.ObjectMetaDie) {
@@ -430,7 +430,7 @@ func TestParentReconciler(t *testing.T) {
 		ExpectEvents: []rtesting.Event{
 			rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "StatusUpdated",
 				`Updated status`),
-			rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Updated", `Updated`),
+			rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Updated", `Updated finalizers`),
 		},
 		ExpectStatusUpdates: []client.Object{
 			resource.StatusDie(func(d *dies.TestResourceStatusDie) {

--- a/reconcilers/reconcilers_validate_test.go
+++ b/reconcilers/reconcilers_validate_test.go
@@ -14,80 +14,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func TestParentReconciler_validate(t *testing.T) {
-	tests := []struct {
-		name       string
-		parent     client.Object
-		reconciler *ParentReconciler
-		shouldErr  string
-	}{
-		{
-			name:       "empty",
-			parent:     &corev1.ConfigMap{},
-			reconciler: &ParentReconciler{},
-		},
-		{
-			name:   "valid",
-			parent: &corev1.ConfigMap{},
-			reconciler: &ParentReconciler{
-				Finalize: func(ctx context.Context, parent *corev1.ConfigMap) error {
-					return nil
-				},
-			},
-		},
-		{
-			name:   "Finalize num in",
-			parent: &corev1.ConfigMap{},
-			reconciler: &ParentReconciler{
-				Finalize: func() error {
-					return nil
-				},
-			},
-			shouldErr: "ParentReconciler Finalize must have correct signature: func(context.Context, *v1.ConfigMap) error, found: func() error",
-		},
-		{
-			name:   "Finalize in 1",
-			parent: &corev1.ConfigMap{},
-			reconciler: &ParentReconciler{
-				Finalize: func(ctx context.Context, parent *corev1.Secret) error {
-					return nil
-				},
-			},
-			shouldErr: "ParentReconciler Finalize must have correct signature: func(context.Context, *v1.ConfigMap) error, found: func(context.Context, *v1.Secret) error",
-		},
-		{
-			name:   "Finalize num out",
-			parent: &corev1.ConfigMap{},
-			reconciler: &ParentReconciler{
-				Finalize: func(ctx context.Context, parent *corev1.ConfigMap) (ctrl.Result, error) {
-					return ctrl.Result{}, nil
-				},
-			},
-			shouldErr: "ParentReconciler Finalize must have correct signature: func(context.Context, *v1.ConfigMap) error, found: func(context.Context, *v1.ConfigMap) (reconcile.Result, error)",
-		},
-		{
-			name:   "Finalize out 1",
-			parent: &corev1.ConfigMap{},
-			reconciler: &ParentReconciler{
-				Finalize: func(ctx context.Context, parent *corev1.ConfigMap) *ctrl.Result {
-					return nil
-				},
-			},
-			shouldErr: "ParentReconciler Finalize must have correct signature: func(context.Context, *v1.ConfigMap) error, found: func(context.Context, *v1.ConfigMap) *reconcile.Result",
-		},
-	}
-
-	for _, c := range tests {
-		t.Run(c.name, func(t *testing.T) {
-			ctx := StashCastParentType(context.TODO(), c.parent)
-			err := c.reconciler.validate(ctx)
-			if (err != nil) != (c.shouldErr != "") || (c.shouldErr != "" && c.shouldErr != err.Error()) {
-				t.Errorf("validate() error = %q, shouldErr %q", err, c.shouldErr)
-			}
-		})
-	}
-}
-
 func TestSyncReconciler_validate(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -106,6 +32,18 @@ func TestSyncReconciler_validate(t *testing.T) {
 			parent: &corev1.ConfigMap{},
 			reconciler: &SyncReconciler{
 				Sync: func(ctx context.Context, parent *corev1.ConfigMap) error {
+					return nil
+				},
+			},
+		},
+		{
+			name:   "valid with Finalize",
+			parent: &corev1.ConfigMap{},
+			reconciler: &SyncReconciler{
+				Sync: func(ctx context.Context, parent *corev1.ConfigMap) error {
+					return nil
+				},
+				Finalize: func(ctx context.Context, parent *corev1.ConfigMap) error {
 					return nil
 				},
 			},
@@ -167,6 +105,58 @@ func TestSyncReconciler_validate(t *testing.T) {
 				},
 			},
 			shouldErr: "SyncReconciler must implement Sync: func(context.Context, *v1.ConfigMap) error | func(context.Context, *v1.ConfigMap) (ctrl.Result, error), found: func(context.Context, *v1.ConfigMap) (reconcile.Result, string)",
+		},
+		{
+			name:   "Finalize num in",
+			parent: &corev1.ConfigMap{},
+			reconciler: &SyncReconciler{
+				Sync: func(ctx context.Context, parent *corev1.ConfigMap) error {
+					return nil
+				},
+				Finalize: func() error {
+					return nil
+				},
+			},
+			shouldErr: "SyncReconciler Finalize must have correct signature: func(context.Context, *v1.ConfigMap) error, found: func() error",
+		},
+		{
+			name:   "Finalize in 1",
+			parent: &corev1.ConfigMap{},
+			reconciler: &SyncReconciler{
+				Sync: func(ctx context.Context, parent *corev1.ConfigMap) error {
+					return nil
+				},
+				Finalize: func(ctx context.Context, parent *corev1.Secret) error {
+					return nil
+				},
+			},
+			shouldErr: "SyncReconciler Finalize must have correct signature: func(context.Context, *v1.ConfigMap) error, found: func(context.Context, *v1.Secret) error",
+		},
+		{
+			name:   "Finalize num out",
+			parent: &corev1.ConfigMap{},
+			reconciler: &SyncReconciler{
+				Sync: func(ctx context.Context, parent *corev1.ConfigMap) error {
+					return nil
+				},
+				Finalize: func(ctx context.Context, parent *corev1.ConfigMap) (ctrl.Result, error) {
+					return ctrl.Result{}, nil
+				},
+			},
+			shouldErr: "SyncReconciler Finalize must have correct signature: func(context.Context, *v1.ConfigMap) error, found: func(context.Context, *v1.ConfigMap) (reconcile.Result, error)",
+		},
+		{
+			name:   "Finalize out 1",
+			parent: &corev1.ConfigMap{},
+			reconciler: &SyncReconciler{
+				Sync: func(ctx context.Context, parent *corev1.ConfigMap) error {
+					return nil
+				},
+				Finalize: func(ctx context.Context, parent *corev1.ConfigMap) *ctrl.Result {
+					return nil
+				},
+			},
+			shouldErr: "SyncReconciler Finalize must have correct signature: func(context.Context, *v1.ConfigMap) error, found: func(context.Context, *v1.ConfigMap) *reconcile.Result",
 		},
 	}
 


### PR DESCRIPTION
Currently, the `ParentReconciler` does not reconcile on a delete request. This leads to some reconcilers not being implementable in reconciler-runtime if they want to do cleanup on a delete (outside of owner reference garbage collection).

The typical way to do this in Kubernetes is to have the reconciler add a finalizer to the resource on first reconcile which blocks deletion, and when it reconciles on deletion, it cleans up and removes said finalizer (see: [Finalizers](https://kubernetes.io/docs/concepts/overview/working-with-objects/finalizers/)).

This PR aims to create an abstraction over the finalizers, seeing them as an implementation detail. It proposes the following:

- An optional `Finalize` method on the Parent reconciler with signature:

  ```go
  func(ctx context.Context, parent client.Object) error
  ```

  This method would be called on a delete reconcile and if successful, finalizer is removed.

- Allow delete reconciles for `ParentReconciler` if the `Finalize` method is present.
- Add the a deterministic finalizer on non-delete reconciles of `ParentReconciler` if the `Finalize` method is present.