### PR TITLE
Finalizers

### DIFF
--- a/reconcilers/reconcilers.go
+++ b/reconcilers/reconcilers.go
@@ -347,7 +347,7 @@ type SyncReconciler struct {
 	// +optional
 	Setup func(ctx context.Context, mgr ctrl.Manager, bldr *builder.Builder) error
 
-	// SyncDuringFinalization indicates the the Sync method should be called regardless of whether
+	// SyncDuringFinalization indicates the Sync method should be called when the resource is pending deletion.
 	SyncDuringFinalization bool
 
 	// Sync does whatever work is necessary for the reconciler.

--- a/reconcilers/reconcilers.go
+++ b/reconcilers/reconcilers.go
@@ -797,6 +797,9 @@ func (r *ChildReconciler) Reconcile(ctx context.Context, parent client.Object) (
 	}
 
 	child, err := r.reconcile(ctx, parent)
+	if parent.GetDeletionTimestamp() != nil {
+		return ctrl.Result{}, err
+	}
 	if err != nil {
 		if apierrs.IsAlreadyExists(err) {
 			// check if the resource blocking create is owned by the parent.

--- a/reconcilers/reconcilers_test.go
+++ b/reconcilers/reconcilers_test.go
@@ -350,6 +350,8 @@ func TestSyncReconciler(t *testing.T) {
 	testNamespace := "test-namespace"
 	testName := "test-resource"
 
+	now := metav1.Now()
+
 	scheme := runtime.NewScheme()
 	_ = resources.AddToScheme(scheme)
 
@@ -414,6 +416,117 @@ func TestSyncReconciler(t *testing.T) {
 			},
 		},
 		ShouldPanic: true,
+	}, {
+		Name:   "should not finalize non-deleted resources",
+		Parent: resource,
+		Metadata: map[string]interface{}{
+			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+				return &reconcilers.SyncReconciler{
+					Sync: func(ctx context.Context, parent *resources.TestResource) (ctrl.Result, error) {
+						return ctrl.Result{RequeueAfter: 2 * time.Hour}, nil
+					},
+					Finalize: func(ctx context.Context, parent *resources.TestResource) (ctrl.Result, error) {
+						t.Errorf("reconciler should not call finalize for non-deleted resources")
+						return ctrl.Result{RequeueAfter: 3 * time.Hour}, nil
+					},
+				}
+			},
+		},
+		ExpectedResult: reconcile.Result{RequeueAfter: 2 * time.Hour},
+	}, {
+		Name: "should not finalize deleted resources",
+		Parent: resource.
+			MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+				d.DeletionTimestamp(&now)
+			}),
+		Metadata: map[string]interface{}{
+			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+				return &reconcilers.SyncReconciler{
+					Sync: func(ctx context.Context, parent *resources.TestResource) (ctrl.Result, error) {
+						t.Errorf("reconciler should not call sync for deleted resources")
+						return ctrl.Result{RequeueAfter: 2 * time.Hour}, nil
+					},
+					Finalize: func(ctx context.Context, parent *resources.TestResource) (ctrl.Result, error) {
+						return ctrl.Result{RequeueAfter: 3 * time.Hour}, nil
+					},
+				}
+			},
+		},
+		ExpectedResult: reconcile.Result{RequeueAfter: 3 * time.Hour},
+	}, {
+		Name: "should finalize and sync deleted resources when asked to",
+		Parent: resource.
+			MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+				d.DeletionTimestamp(&now)
+			}),
+		Metadata: map[string]interface{}{
+			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+				return &reconcilers.SyncReconciler{
+					SyncDuringFinalization: true,
+					Sync: func(ctx context.Context, parent *resources.TestResource) (ctrl.Result, error) {
+						return ctrl.Result{RequeueAfter: 2 * time.Hour}, nil
+					},
+					Finalize: func(ctx context.Context, parent *resources.TestResource) (ctrl.Result, error) {
+						return ctrl.Result{RequeueAfter: 3 * time.Hour}, nil
+					},
+				}
+			},
+		},
+		ExpectedResult: reconcile.Result{RequeueAfter: 2 * time.Hour},
+	}, {
+		Name: "should finalize and sync deleted resources when asked to, shorter resync wins",
+		Parent: resource.
+			MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+				d.DeletionTimestamp(&now)
+			}),
+		Metadata: map[string]interface{}{
+			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+				return &reconcilers.SyncReconciler{
+					SyncDuringFinalization: true,
+					Sync: func(ctx context.Context, parent *resources.TestResource) (ctrl.Result, error) {
+						return ctrl.Result{RequeueAfter: 3 * time.Hour}, nil
+					},
+					Finalize: func(ctx context.Context, parent *resources.TestResource) (ctrl.Result, error) {
+						return ctrl.Result{RequeueAfter: 2 * time.Hour}, nil
+					},
+				}
+			},
+		},
+		ExpectedResult: reconcile.Result{RequeueAfter: 2 * time.Hour},
+	}, {
+		Name: "finalize is optional",
+		Parent: resource.
+			MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+				d.DeletionTimestamp(&now)
+			}),
+		Metadata: map[string]interface{}{
+			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+				return &reconcilers.SyncReconciler{
+					Sync: func(ctx context.Context, parent *resources.TestResource) error {
+						return nil
+					},
+				}
+			},
+		},
+	}, {
+		Name: "finalize error",
+		Parent: resource.
+			MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+				d.DeletionTimestamp(&now)
+			}),
+		Metadata: map[string]interface{}{
+			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+				return &reconcilers.SyncReconciler{
+					Sync: func(ctx context.Context, parent *resources.TestResource) error {
+						return nil
+					},
+					Finalize: func(ctx context.Context, parent *resources.TestResource) error {
+						return fmt.Errorf("syncreconciler finalize error")
+					},
+				}
+			},
+		},
+		ShouldErr: true,
 	}}
 
 	rts.Test(t, scheme, func(t *testing.T, rtc *rtesting.SubReconcilerTestCase, c reconcilers.Config) reconcilers.SubReconciler {
@@ -424,6 +537,7 @@ func TestSyncReconciler(t *testing.T) {
 func TestChildReconciler(t *testing.T) {
 	testNamespace := "test-namespace"
 	testName := "test-resource"
+	testFinalizer := "test.finalizer"
 
 	scheme := runtime.NewScheme()
 	_ = resources.AddToScheme(scheme)
@@ -553,6 +667,49 @@ func TestChildReconciler(t *testing.T) {
 			configMapCreate,
 		},
 	}, {
+		Name: "create child with finalizer",
+		Parent: resource.
+			SpecDie(func(d *dies.TestResourceSpecDie) {
+				d.AddField("foo", "bar")
+			}),
+		Metadata: map[string]interface{}{
+			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+				r := defaultChildReconciler(c)
+				r.Finalizer = testFinalizer
+				return r
+			},
+		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "FinalizerPatched",
+				`Patched finalizer %q`, testFinalizer),
+			rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Created",
+				`Created ConfigMap %q`, testName),
+		},
+		ExpectParent: resourceReady.
+			MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+				d.Finalizers(testFinalizer)
+				d.ResourceVersion("1000")
+			}).
+			SpecDie(func(d *dies.TestResourceSpecDie) {
+				d.AddField("foo", "bar")
+			}).
+			StatusDie(func(d *dies.TestResourceStatusDie) {
+				d.AddField("foo", "bar")
+			}),
+		ExpectCreates: []client.Object{
+			configMapCreate,
+		},
+		ExpectPatches: []rtesting.PatchRef{
+			{
+				Group:     "testing.reconciler.runtime",
+				Kind:      "TestResource",
+				Namespace: testNamespace,
+				Name:      testName,
+				PatchType: types.MergePatchType,
+				Patch:     []byte(`{"metadata":{"finalizers":["test.finalizer"],"resourceVersion":"999"}}`),
+			},
+		},
+	}, {
 		Name: "update child",
 		Parent: resourceReady.
 			SpecDie(func(d *dies.TestResourceSpecDie) {
@@ -588,6 +745,102 @@ func TestChildReconciler(t *testing.T) {
 				AddData("new", "field"),
 		},
 	}, {
+		Name: "update child, preserve finalizers",
+		Parent: resourceReady.
+			MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+				d.Finalizers(testFinalizer, "some.other.finalizer")
+			}).
+			SpecDie(func(d *dies.TestResourceSpecDie) {
+				d.AddField("foo", "bar")
+				d.AddField("new", "field")
+			}).
+			StatusDie(func(d *dies.TestResourceStatusDie) {
+				d.AddField("foo", "bar")
+			}),
+		GivenObjects: []client.Object{
+			configMapGiven,
+		},
+		Metadata: map[string]interface{}{
+			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+				r := defaultChildReconciler(c)
+				r.Finalizer = testFinalizer
+				return r
+			},
+		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Updated",
+				`Updated ConfigMap %q`, testName),
+		},
+		ExpectParent: resourceReady.
+			MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+				d.Finalizers(testFinalizer, "some.other.finalizer")
+			}).
+			SpecDie(func(d *dies.TestResourceSpecDie) {
+				d.AddField("foo", "bar")
+				d.AddField("new", "field")
+			}).
+			StatusDie(func(d *dies.TestResourceStatusDie) {
+				d.AddField("foo", "bar")
+				d.AddField("new", "field")
+			}),
+		ExpectUpdates: []client.Object{
+			configMapGiven.
+				AddData("new", "field"),
+		},
+	}, {
+		Name: "update child, restoring missing finalizer",
+		Parent: resourceReady.
+			SpecDie(func(d *dies.TestResourceSpecDie) {
+				d.AddField("foo", "bar")
+				d.AddField("new", "field")
+			}).
+			StatusDie(func(d *dies.TestResourceStatusDie) {
+				d.AddField("foo", "bar")
+			}),
+		GivenObjects: []client.Object{
+			configMapGiven,
+		},
+		Metadata: map[string]interface{}{
+			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+				r := defaultChildReconciler(c)
+				r.Finalizer = testFinalizer
+				return r
+			},
+		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "FinalizerPatched",
+				`Patched finalizer %q`, testFinalizer),
+			rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Updated",
+				`Updated ConfigMap %q`, testName),
+		},
+		ExpectParent: resourceReady.
+			MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+				d.Finalizers(testFinalizer)
+				d.ResourceVersion("1000")
+			}).
+			SpecDie(func(d *dies.TestResourceSpecDie) {
+				d.AddField("foo", "bar")
+				d.AddField("new", "field")
+			}).
+			StatusDie(func(d *dies.TestResourceStatusDie) {
+				d.AddField("foo", "bar")
+				d.AddField("new", "field")
+			}),
+		ExpectUpdates: []client.Object{
+			configMapGiven.
+				AddData("new", "field"),
+		},
+		ExpectPatches: []rtesting.PatchRef{
+			{
+				Group:     "testing.reconciler.runtime",
+				Kind:      "TestResource",
+				Namespace: testNamespace,
+				Name:      testName,
+				PatchType: types.MergePatchType,
+				Patch:     []byte(`{"metadata":{"finalizers":["test.finalizer"],"resourceVersion":"999"}}`),
+			},
+		},
+	}, {
 		Name:   "delete child",
 		Parent: resourceReady,
 		GivenObjects: []client.Object{
@@ -596,6 +849,69 @@ func TestChildReconciler(t *testing.T) {
 		Metadata: map[string]interface{}{
 			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
 				return defaultChildReconciler(c)
+			},
+		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Deleted",
+				`Deleted ConfigMap %q`, testName),
+		},
+		ExpectDeletes: []rtesting.DeleteRef{
+			{Group: "", Kind: "ConfigMap", Namespace: testNamespace, Name: testName},
+		},
+	}, {
+		Name: "delete child, clearing finalizer",
+		Parent: resourceReady.
+			MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+				d.Finalizers(testFinalizer)
+			}),
+		GivenObjects: []client.Object{
+			configMapGiven,
+		},
+		Metadata: map[string]interface{}{
+			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+				r := defaultChildReconciler(c)
+				r.Finalizer = testFinalizer
+				return r
+			},
+		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Deleted",
+				`Deleted ConfigMap %q`, testName),
+			rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "FinalizerPatched",
+				`Patched finalizer %q`, testFinalizer),
+		},
+		ExpectParent: resourceReady.
+			MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+				d.Finalizers()
+				d.ResourceVersion("1000")
+			}),
+		ExpectDeletes: []rtesting.DeleteRef{
+			{Group: "", Kind: "ConfigMap", Namespace: testNamespace, Name: testName},
+		},
+		ExpectPatches: []rtesting.PatchRef{
+			{
+				Group:     "testing.reconciler.runtime",
+				Kind:      "TestResource",
+				Namespace: testNamespace,
+				Name:      testName,
+				PatchType: types.MergePatchType,
+				Patch:     []byte(`{"metadata":{"finalizers":null,"resourceVersion":"999"}}`),
+			},
+		},
+	}, {
+		Name: "delete child, preserve other finalizer",
+		Parent: resourceReady.
+			MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+				d.Finalizers("some.other.finalizer")
+			}),
+		GivenObjects: []client.Object{
+			configMapGiven,
+		},
+		Metadata: map[string]interface{}{
+			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+				r := defaultChildReconciler(c)
+				r.Finalizer = testFinalizer
+				return r
 			},
 		},
 		ExpectEvents: []rtesting.Event{
@@ -826,6 +1142,76 @@ func TestChildReconciler(t *testing.T) {
 		},
 		ExpectCreates: []client.Object{
 			configMapCreate,
+		},
+		ShouldErr: true,
+	}, {
+		Name: "error adding finalizer",
+		Parent: resource.
+			SpecDie(func(d *dies.TestResourceSpecDie) {
+				d.AddField("foo", "bar")
+			}),
+		Metadata: map[string]interface{}{
+			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+				r := defaultChildReconciler(c)
+				r.Finalizer = testFinalizer
+				return r
+			},
+		},
+		WithReactors: []rtesting.ReactionFunc{
+			rtesting.InduceFailure("patch", "TestResource"),
+		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(resource, scheme, corev1.EventTypeWarning, "FinalizerPatchFailed",
+				`Failed to patch finalizer %q: inducing failure for patch TestResource`, testFinalizer),
+		},
+		ExpectPatches: []rtesting.PatchRef{
+			{
+				Group:     "testing.reconciler.runtime",
+				Kind:      "TestResource",
+				Namespace: testNamespace,
+				Name:      testName,
+				PatchType: types.MergePatchType,
+				Patch:     []byte(`{"metadata":{"finalizers":["test.finalizer"],"resourceVersion":"999"}}`),
+			},
+		},
+		ShouldErr: true,
+	}, {
+		Name: "error clearing finalizer",
+		Parent: resourceReady.
+			MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+				d.Finalizers(testFinalizer)
+			}),
+		GivenObjects: []client.Object{
+			configMapGiven,
+		},
+		Metadata: map[string]interface{}{
+			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+				r := defaultChildReconciler(c)
+				r.Finalizer = testFinalizer
+				return r
+			},
+		},
+		WithReactors: []rtesting.ReactionFunc{
+			rtesting.InduceFailure("patch", "TestResource"),
+		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Deleted",
+				`Deleted ConfigMap %q`, testName),
+			rtesting.NewEvent(resource, scheme, corev1.EventTypeWarning, "FinalizerPatchFailed",
+				`Failed to patch finalizer %q: inducing failure for patch TestResource`, testFinalizer),
+		},
+		ExpectDeletes: []rtesting.DeleteRef{
+			{Group: "", Kind: "ConfigMap", Namespace: testNamespace, Name: testName},
+		},
+		ExpectPatches: []rtesting.PatchRef{
+			{
+				Group:     "testing.reconciler.runtime",
+				Kind:      "TestResource",
+				Namespace: testNamespace,
+				Name:      testName,
+				PatchType: types.MergePatchType,
+				Patch:     []byte(`{"metadata":{"finalizers":null,"resourceVersion":"999"}}`),
+			},
 		},
 		ShouldErr: true,
 	}, {

--- a/reconcilers/reconcilers_validate_test.go
+++ b/reconcilers/reconcilers_validate_test.go
@@ -95,6 +95,94 @@ func TestSyncReconciler_validate(t *testing.T) {
 			},
 			shouldErr: "SyncReconciler must implement Sync: func(context.Context, *v1.ConfigMap) error | func(context.Context, *v1.ConfigMap) (ctrl.Result, error), found: func(context.Context, *v1.ConfigMap) (reconcile.Result, string)",
 		},
+		{
+			name:   "valid Finalize",
+			parent: &corev1.ConfigMap{},
+			reconciler: &SyncReconciler{
+				Sync: func(ctx context.Context, parent *corev1.ConfigMap) error {
+					return nil
+				},
+				Finalize: func(ctx context.Context, parent *corev1.ConfigMap) error {
+					return nil
+				},
+			},
+		},
+		{
+			name:   "valid Finalize with result",
+			parent: &corev1.ConfigMap{},
+			reconciler: &SyncReconciler{
+				Sync: func(ctx context.Context, parent *corev1.ConfigMap) error {
+					return nil
+				},
+				Finalize: func(ctx context.Context, parent *corev1.ConfigMap) (ctrl.Result, error) {
+					return ctrl.Result{}, nil
+				},
+			},
+		},
+		{
+			name:   "Finalize num in",
+			parent: &corev1.ConfigMap{},
+			reconciler: &SyncReconciler{
+				Sync: func(ctx context.Context, parent *corev1.ConfigMap) error {
+					return nil
+				},
+				Finalize: func() error {
+					return nil
+				},
+			},
+			shouldErr: "SyncReconciler must implement Finalize: nil | func(context.Context, *v1.ConfigMap) error | func(context.Context, *v1.ConfigMap) (ctrl.Result, error), found: func() error",
+		},
+		{
+			name:   "Finalize in 1",
+			parent: &corev1.ConfigMap{},
+			reconciler: &SyncReconciler{
+				Sync: func(ctx context.Context, parent *corev1.ConfigMap) error {
+					return nil
+				},
+				Finalize: func(ctx context.Context, parent *corev1.Secret) error {
+					return nil
+				},
+			},
+			shouldErr: "SyncReconciler must implement Finalize: nil | func(context.Context, *v1.ConfigMap) error | func(context.Context, *v1.ConfigMap) (ctrl.Result, error), found: func(context.Context, *v1.Secret) error",
+		},
+		{
+			name:   "Finalize num out",
+			parent: &corev1.ConfigMap{},
+			reconciler: &SyncReconciler{
+				Sync: func(ctx context.Context, parent *corev1.ConfigMap) error {
+					return nil
+				},
+				Finalize: func(ctx context.Context, parent *corev1.ConfigMap) {
+				},
+			},
+			shouldErr: "SyncReconciler must implement Finalize: nil | func(context.Context, *v1.ConfigMap) error | func(context.Context, *v1.ConfigMap) (ctrl.Result, error), found: func(context.Context, *v1.ConfigMap)",
+		},
+		{
+			name:   "Finalize out 1",
+			parent: &corev1.ConfigMap{},
+			reconciler: &SyncReconciler{
+				Sync: func(ctx context.Context, parent *corev1.ConfigMap) error {
+					return nil
+				},
+				Finalize: func(ctx context.Context, parent *corev1.ConfigMap) string {
+					return ""
+				},
+			},
+			shouldErr: "SyncReconciler must implement Finalize: nil | func(context.Context, *v1.ConfigMap) error | func(context.Context, *v1.ConfigMap) (ctrl.Result, error), found: func(context.Context, *v1.ConfigMap) string",
+		},
+		{
+			name:   "Finalize result out 1",
+			parent: &corev1.ConfigMap{},
+			reconciler: &SyncReconciler{
+				Sync: func(ctx context.Context, parent *corev1.ConfigMap) error {
+					return nil
+				},
+				Finalize: func(ctx context.Context, parent *corev1.ConfigMap) (ctrl.Result, string) {
+					return ctrl.Result{}, ""
+				},
+			},
+			shouldErr: "SyncReconciler must implement Finalize: nil | func(context.Context, *v1.ConfigMap) error | func(context.Context, *v1.ConfigMap) (ctrl.Result, error), found: func(context.Context, *v1.ConfigMap) (reconcile.Result, string)",
+		},
 	}
 
 	for _, c := range tests {

--- a/testing/reconciler.go
+++ b/testing/reconciler.go
@@ -423,6 +423,20 @@ func NewDeleteRef(action DeleteAction) DeleteRef {
 	}
 }
 
+func NewDeleteRefFromObject(obj client.Object, scheme *runtime.Scheme) DeleteRef {
+	gvks, _, err := scheme.ObjectKinds(obj.DeepCopyObject())
+	if err != nil {
+		panic(err)
+	}
+
+	return DeleteRef{
+		Group:     gvks[0].Group,
+		Kind:      gvks[0].Kind,
+		Namespace: obj.GetNamespace(),
+		Name:      obj.GetName(),
+	}
+}
+
 type DeleteCollectionRef struct {
 	Group     string
 	Kind      string

--- a/testing/subreconciler.go
+++ b/testing/subreconciler.go
@@ -166,6 +166,10 @@ func (tc *SubReconcilerTestCase) Run(t *testing.T, scheme *runtime.Scheme, facto
 	ctx = reconcilers.StashParentConfig(ctx, c)
 
 	parent := tc.Parent.DeepCopyObject().(client.Object)
+	if parent.GetResourceVersion() == "" {
+		// this value is also set by the test client when resource are added as givens
+		parent.SetResourceVersion("999")
+	}
 	ctx = reconcilers.StashParentType(ctx, parent.DeepCopyObject().(client.Object))
 	ctx = reconcilers.StashCastParentType(ctx, parent.DeepCopyObject().(client.Object))
 
@@ -200,6 +204,10 @@ func (tc *SubReconcilerTestCase) Run(t *testing.T, scheme *runtime.Scheme, facto
 	expectedParent := tc.Parent.DeepCopyObject().(client.Object)
 	if tc.ExpectParent != nil {
 		expectedParent = tc.ExpectParent.DeepCopyObject().(client.Object)
+	}
+	if expectedParent.GetResourceVersion() == "" {
+		// mirror defaulting of the parent
+		expectedParent.SetResourceVersion("999")
 	}
 	if diff := cmp.Diff(expectedParent, parent, IgnoreLastTransitionTime, SafeDeployDiff, IgnoreTypeMeta, cmpopts.EquateEmpty()); diff != "" {
 		t.Errorf("Unexpected parent mutations(-expected, +actual): %s", diff)


### PR DESCRIPTION
Finalizers allow a reconciler to clean up state for a resource that has
been deleted by a client, and not yet fully removed. Resources with
finalizers will stay in this terminating state until all finalizers are
cleared from the resource.

ParentReconcilers will now reconcile resources that are terminating as
long as they also have a pending finalizer.

SyncReconcilers have a new, optional, Finalize method that is called
when the resource is terminating. The Sync method will not be called
unless SyncDuringFinalization is true. Users are responsible to add and
clear finalizers from resources.

The AddParentFinalizer and ClearParentFinalizer functions will patch the
resource. These method work with cast parents objects and use the same
client the ParentReconciler used to originally load the parent resource,
so they can be called inside SubReconcilers that use a different client.

ChildReconcilers have a Finalizer field that when set will ensure that
value is set on the parent resource finalizers before creating/updating
a child resource. It will also clear that finalizer after the child is
deleted. When the parent is terminating, the DesiredChild method is not
called and existing children are deleted.

Signed-off-by: Scott Andrews <andrewssc@vmware.com>