### PR TITLE
Move logger into context

### DIFF
--- a/reconcilers/enqueuer.go
+++ b/reconcilers/enqueuer.go
@@ -6,6 +6,8 @@ SPDX-License-Identifier: Apache-2.0
 package reconcilers
 
 import (
+	"context"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -15,7 +17,7 @@ import (
 	"github.com/vmware-labs/reconciler-runtime/tracker"
 )
 
-func EnqueueTracked(by client.Object, t tracker.Tracker, s *runtime.Scheme) handler.EventHandler {
+func EnqueueTracked(ctx context.Context, by client.Object, t tracker.Tracker, s *runtime.Scheme) handler.EventHandler {
 	return handler.EnqueueRequestsFromMapFunc(
 		func(a client.Object) []reconcile.Request {
 			var requests []reconcile.Request
@@ -29,7 +31,7 @@ func EnqueueTracked(by client.Object, t tracker.Tracker, s *runtime.Scheme) hand
 				gvks[0],
 				types.NamespacedName{Namespace: a.GetNamespace(), Name: a.GetName()},
 			)
-			for _, item := range t.Lookup(key) {
+			for _, item := range t.Lookup(ctx, key) {
 				requests = append(requests, reconcile.Request{NamespacedName: item})
 			}
 

--- a/reconcilers/logger.go
+++ b/reconcilers/logger.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2022 VMware, Inc.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package reconcilers
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/go-logr/logr"
+)
+
+var (
+	_ logr.LogSink = (*warnOnceLogSink)(nil)
+)
+
+// Deprecated
+func newWarnOnceLogger(log logr.Logger) logr.Logger {
+	return logr.New(&warnOnceLogSink{
+		sink: log.GetSink(),
+	})
+}
+
+// Deprecated
+type warnOnceLogSink struct {
+	sink logr.LogSink
+	once sync.Once
+}
+
+func (s *warnOnceLogSink) Init(info logr.RuntimeInfo) {
+	s.sink.Init(info)
+}
+
+func (s *warnOnceLogSink) Enabled(level int) bool {
+	return s.sink.Enabled(level)
+}
+
+func (s *warnOnceLogSink) Info(level int, msg string, keysAndValues ...interface{}) {
+	s.warn()
+	s.sink.Info(level, msg, keysAndValues...)
+}
+
+func (s *warnOnceLogSink) Error(err error, msg string, keysAndValues ...interface{}) {
+	s.warn()
+	s.sink.Error(err, msg, keysAndValues...)
+}
+
+func (s *warnOnceLogSink) WithValues(keysAndValues ...interface{}) logr.LogSink {
+	return &warnOnceLogSink{
+		sink: s.sink.WithValues(keysAndValues...),
+		once: s.once,
+	}
+}
+
+func (s *warnOnceLogSink) WithName(name string) logr.LogSink {
+	return &warnOnceLogSink{
+		sink: s.sink.WithName(name),
+		once: s.once,
+	}
+}
+
+func (s *warnOnceLogSink) warn() {
+	s.once.Do(func() {
+		s.sink.Error(fmt.Errorf("Config.Log is deprecated"), "use a logger from the context: `log := logr.FromContext(ctx)`")
+	})
+}

--- a/testing/tracker.go
+++ b/testing/tracker.go
@@ -6,9 +6,9 @@ SPDX-License-Identifier: Apache-2.0
 package testing
 
 import (
+	"context"
 	"time"
 
-	"github.com/go-logr/logr"
 	"github.com/vmware-labs/reconciler-runtime/tracker"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -54,7 +54,7 @@ func NewTrackRequest(t, b client.Object, scheme *runtime.Scheme) TrackRequest {
 const maxDuration = time.Duration(1<<63 - 1)
 
 func createTracker() *mockTracker {
-	return &mockTracker{Tracker: tracker.New(maxDuration, logr.Discard()), reqs: []TrackRequest{}}
+	return &mockTracker{Tracker: tracker.New(maxDuration), reqs: []TrackRequest{}}
 }
 
 type mockTracker struct {
@@ -64,15 +64,11 @@ type mockTracker struct {
 
 var _ tracker.Tracker = &mockTracker{}
 
-func (t *mockTracker) Track(ref tracker.Key, obj types.NamespacedName) {
-	t.Tracker.Track(ref, obj)
+func (t *mockTracker) Track(ctx context.Context, ref tracker.Key, obj types.NamespacedName) {
+	t.Tracker.Track(ctx, ref, obj)
 	t.reqs = append(t.reqs, TrackRequest{Tracked: ref, Tracker: obj})
 }
 
 func (t *mockTracker) getTrackRequests() []TrackRequest {
-	result := []TrackRequest{}
-	for _, req := range t.reqs {
-		result = append(result, req)
-	}
-	return result
+	return append([]TrackRequest{}, t.reqs...)
 }

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -23,6 +23,7 @@ SPDX-License-Identifier: Apache-2.0
 package tracker
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -37,10 +38,10 @@ import (
 type Tracker interface {
 	// Track tells us that "obj" is tracking changes to the
 	// referenced object.
-	Track(ref Key, obj types.NamespacedName)
+	Track(ctx context.Context, ref Key, obj types.NamespacedName)
 
 	// Lookup returns actively tracked objects for the reference.
-	Lookup(ref Key) []types.NamespacedName
+	Lookup(ctx context.Context, ref Key) []types.NamespacedName
 }
 
 func NewKey(gvk schema.GroupVersionKind, namespacedName types.NamespacedName) Key {
@@ -63,9 +64,8 @@ func (k *Key) String() string {
 // register a particular resource as watching a resource for
 // a particular lease duration.  This watch must be refreshed
 // periodically (e.g. by a controller resync) or it will expire.
-func New(lease time.Duration, log logr.Logger) Tracker {
+func New(lease time.Duration) Tracker {
 	return &impl{
-		log:           log,
 		leaseDuration: lease,
 	}
 }
@@ -90,7 +90,9 @@ var _ Tracker = (*impl)(nil)
 type set map[types.NamespacedName]time.Time
 
 // Track implements Tracker.
-func (i *impl) Track(ref Key, obj types.NamespacedName) {
+func (i *impl) Track(ctx context.Context, ref Key, obj types.NamespacedName) {
+	log := logr.FromContextOrDiscard(ctx).WithName("tracker")
+
 	i.m.Lock()
 	defer i.m.Unlock()
 	if i.mapping == nil {
@@ -106,7 +108,7 @@ func (i *impl) Track(ref Key, obj types.NamespacedName) {
 
 	i.mapping[ref.String()] = l
 
-	i.log.Info("tracking resource", "ref", ref.String(), "obj", obj.String(), "ttl", l[obj].UTC().Format(time.RFC3339))
+	log.Info("tracking resource", "ref", ref.String(), "obj", obj.String(), "ttl", l[obj].UTC().Format(time.RFC3339))
 }
 
 func isExpired(expiry time.Time) bool {
@@ -114,7 +116,9 @@ func isExpired(expiry time.Time) bool {
 }
 
 // Lookup implements Tracker.
-func (i *impl) Lookup(ref Key) []types.NamespacedName {
+func (i *impl) Lookup(ctx context.Context, ref Key) []types.NamespacedName {
+	log := logr.FromContextOrDiscard(ctx).WithName("tracker")
+
 	items := []types.NamespacedName{}
 
 	// TODO(mattmoor): Consider locking the mapping (global) for a
@@ -123,7 +127,7 @@ func (i *impl) Lookup(ref Key) []types.NamespacedName {
 	defer i.m.Unlock()
 	s, ok := i.mapping[ref.String()]
 	if !ok {
-		i.log.V(2).Info("no tracked items found", "ref", ref.String())
+		log.V(2).Info("no tracked items found", "ref", ref.String())
 		return items
 	}
 
@@ -140,7 +144,7 @@ func (i *impl) Lookup(ref Key) []types.NamespacedName {
 		delete(i.mapping, ref.String())
 	}
 
-	i.log.V(1).Info("found tracked items", "ref", ref.String(), "items", items)
+	log.V(1).Info("found tracked items", "ref", ref.String(), "items", items)
 
 	return items
 }


### PR DESCRIPTION
The logger was previously available on the Config object as well as from
the context via `logr.FromContext(ctx)`. While they are the same root
logger, each has a different set of names and values applied to each log
line.

Loading the logger from the context is the preferred approach moving
forward. The logger on the Config is still available, but is deprecated
and will be removed in a future release. The first use of the `c.Log`
methods will trigger an error printed to the log.

Each reconciler in the call chain can enrich the logger as it is passed
deeper in the reconciler hierarchy. Many reconciler have a new `Name`
field that is appended to the logger's name for all log statements under
it. `ParentReconciler`, `ChildReconciler` and `CastParent` provide
default names based on the type they are reconciling. Unique names are
recommended, but are not required, since they only appear in logs and do
not affect the runtime behavior.

Signed-off-by: Scott Andrews <andrewssc@vmware.com>