### PR TITLE
Move config into context

### DIFF
--- a/reconcilers/patch.go
+++ b/reconcilers/patch.go
@@ -62,5 +62,7 @@ func (p *Patch) Apply(rebase client.Object) error {
 	if err != nil {
 		return err
 	}
+	// reset rebase to its empty value before unmarshaling into it
+	replaceWithEmpty(rebase)
 	return json.Unmarshal(patchedBytes, rebase)
 }

--- a/testing/reconciler.go
+++ b/testing/reconciler.go
@@ -164,7 +164,7 @@ func (tc *ReconcilerTestCase) Run(t *testing.T, scheme *runtime.Scheme, factory 
 	})
 
 	if (err != nil) != tc.ShouldErr {
-		t.Errorf("Reconcile() error = %v, ExpectErr %v", err, tc.ShouldErr)
+		t.Errorf("Reconcile() error = %v, ShouldErr %v", err, tc.ShouldErr)
 	}
 	if err == nil {
 		// result is only significant if there wasn't an error


### PR DESCRIPTION
Reconcilers and sub reconcilers use the config object to centralize
common api operations. Previously this config was passed to each
reconciler when it was initialized. However, this makes it harder to
dynamically swap the config at runtime based on the content of a
resource. For example, a resource may specify a service account to use
when creating other resources with least privilege.

The ChildReconciler and SyncReconciler no long allow the Config to be
specified directly. It must be passed in via the context. So that the
RetrieveConfig method can return the Config.

SubReconcilers that need to interact with the parent resource should use
the parent config via RetrieveParentConfig method. In many cases the
config and parent config are one in the same, however, the WithConfig
sub reconciler can inject an alternate config for the nested sub
reconcilers.

Signed-off-by: Scott Andrews <andrewssc@vmware.com>