### PR TITLE
Add RBAC recommendations for controllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,16 @@ func FunctionReconciler(c reconcilers.Config) *reconcilers.ParentReconciler {
 ```
 [full source](https://github.com/projectriff/system/blob/4c3b75327bf99cc37b57ba14df4c65d21dc79d28/pkg/controllers/build/function_reconciler.go#L39-L51)
 
+**Recommended RBAC:**
+
+Replace `<group>` and `<resource>` with values for the parent type.
+
+```go
+// +kubebuilder:rbac:groups=<group>,resources=<resource>,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=<group>,resources=<resource>/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch;create;update;patch;delete
+```
+
 ### SubReconciler
 
 The [`SubReconciler`](https://pkg.go.dev/github.com/vmware-labs/reconciler-runtime/reconcilers#SubReconciler) interface defines the contract between the parent and sub reconcilers.
@@ -195,6 +205,14 @@ func FunctionChildImageReconciler(c reconcilers.Config) reconcilers.SubReconcile
 }
 ```
 [full source](https://github.com/projectriff/system/blob/4c3b75327bf99cc37b57ba14df4c65d21dc79d28/pkg/controllers/build/function_reconciler.go#L76-L151)
+
+**Recommended RBAC:**
+
+Replace `<group>` and `<resource>` with values for the child type.
+
+```go
+// +kubebuilder:rbac:groups=<group>,resources=<resource>,verbs=get;list;watch;create;update;patch;delete
+```
 
 ### Higher-order Reconcilers
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,25 @@ Replace `<group>` and `<resource>` with values for the parent type.
 // +kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch;create;update;patch;delete
 ```
 
+or
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: # any name that is bound to the ServiceAccount used by the client
+rules:
+- apiGroups: ["<group>"]
+  resources: ["<resource>"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: ["<group>"]
+  resources: ["<resource>/status"]
+  verbs: ["get", "update", "patch"]
+- apiGroups: ["core"]
+  resources: ["events"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+```
+
 ### SubReconciler
 
 The [`SubReconciler`](https://pkg.go.dev/github.com/vmware-labs/reconciler-runtime/reconcilers#SubReconciler) interface defines the contract between the parent and sub reconcilers.
@@ -213,6 +232,20 @@ Replace `<group>` and `<resource>` with values for the child type.
 ```go
 // +kubebuilder:rbac:groups=<group>,resources=<resource>,verbs=get;list;watch;create;update;patch;delete
 ```
+
+or
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: # any name that is bound to the ServiceAccount used by the client
+rules:
+- apiGroups: ["<group>"]
+  resources: ["<resource>"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+```
+
 
 ### Higher-order Reconcilers
 


### PR DESCRIPTION
The parent and child reconciler each make client requests based on the
resources being reconciled. We should give guidance to users as to what
RBAC permissions are required to effectively use the reconcilers.

The RBAC permissions are defined as kubebuilder annotations that can be
parsed and converted into a ClusterRole via controller-gen.

Resolves #217 