### PR TITLE
Allow WithConfig to create dynamic configs

### DIFF
--- a/reconcilers/reconcilers_test.go
+++ b/reconcilers/reconcilers_test.go
@@ -1429,7 +1429,9 @@ func TestWithConfig(t *testing.T) {
 				}
 
 				return &reconcilers.WithConfig{
-					Config: c,
+					Config: func(ctx context.Context, _ reconcilers.Config) (reconcilers.Config, error) {
+						return c, nil
+					},
 					Reconciler: &reconcilers.SyncReconciler{
 						Sync: func(ctx context.Context, parent *resources.TestResource) error {
 							ac := reconcilers.RetrieveConfig(ctx)

--- a/reconcilers/reconcilers_validate_test.go
+++ b/reconcilers/reconcilers_validate_test.go
@@ -758,23 +758,17 @@ func TestWithConfig_validate(t *testing.T) {
 			name:   "valid",
 			parent: &corev1.ConfigMap{},
 			reconciler: &WithConfig{
-				Config: config,
-				Reconciler: &SyncReconciler{
-					Sync: func(ctx context.Context, parent *corev1.Secret) error {
-						return nil
-					},
+				Reconciler: &Sequence{},
+				Config: func(ctx context.Context, c Config) (Config, error) {
+					return config, nil
 				},
 			},
 		},
 		{
-			name:   "missing type",
+			name:   "missing config",
 			parent: &corev1.ConfigMap{},
 			reconciler: &WithConfig{
-				Reconciler: &SyncReconciler{
-					Sync: func(ctx context.Context, parent *corev1.Secret) error {
-						return nil
-					},
-				},
+				Reconciler: &Sequence{},
 			},
 			shouldErr: "Config must be defined",
 		},
@@ -782,8 +776,9 @@ func TestWithConfig_validate(t *testing.T) {
 			name:   "missing reconciler",
 			parent: &corev1.ConfigMap{},
 			reconciler: &WithConfig{
-				Config:     config,
-				Reconciler: nil,
+				Config: func(ctx context.Context, c Config) (Config, error) {
+					return config, nil
+				},
 			},
 			shouldErr: "Reconciler must be defined",
 		},


### PR DESCRIPTION
`WithConfig#Config` is now a function that has access to the context and
the current config. A custom config can be created for a specific parent
resource.

This would be a breaking change to `WithConfig`, except that it has not been released yet.

Signed-off-by: Scott Andrews <andrewssc@vmware.com>