### PR TITLE
Include reconciler name in validation errors

### DIFF
--- a/reconcilers/reconcilers.go
+++ b/reconcilers/reconcilers.go
@@ -402,11 +402,11 @@ func (r *SyncReconciler) validate(ctx context.Context) error {
 	//     func(ctx context.Context, parent client.Object) error
 	//     func(ctx context.Context, parent client.Object) (ctrl.Result, error)
 	if r.Sync == nil {
-		return fmt.Errorf("SyncReconciler must implement Sync")
+		return fmt.Errorf("SyncReconciler %q must implement Sync", r.Name)
 	} else {
 		castParentType := RetrieveCastParentType(ctx)
 		fn := reflect.TypeOf(r.Sync)
-		err := fmt.Errorf("SyncReconciler must implement Sync: func(context.Context, %s) error | func(context.Context, %s) (ctrl.Result, error), found: %s", reflect.TypeOf(castParentType), reflect.TypeOf(castParentType), fn)
+		err := fmt.Errorf("SyncReconciler %q must implement Sync: func(context.Context, %s) error | func(context.Context, %s) (ctrl.Result, error), found: %s", r.Name, reflect.TypeOf(castParentType), reflect.TypeOf(castParentType), fn)
 		if fn.NumIn() != 2 ||
 			!reflect.TypeOf((*context.Context)(nil)).Elem().AssignableTo(fn.In(0)) ||
 			!reflect.TypeOf(castParentType).AssignableTo(fn.In(1)) {
@@ -434,7 +434,7 @@ func (r *SyncReconciler) validate(ctx context.Context) error {
 	if r.Finalize != nil {
 		castParentType := RetrieveCastParentType(ctx)
 		fn := reflect.TypeOf(r.Finalize)
-		err := fmt.Errorf("SyncReconciler must implement Finalize: nil | func(context.Context, %s) error | func(context.Context, %s) (ctrl.Result, error), found: %s", reflect.TypeOf(castParentType), reflect.TypeOf(castParentType), fn)
+		err := fmt.Errorf("SyncReconciler %q must implement Finalize: nil | func(context.Context, %s) error | func(context.Context, %s) (ctrl.Result, error), found: %s", r.Name, reflect.TypeOf(castParentType), reflect.TypeOf(castParentType), fn)
 		if fn.NumIn() != 2 ||
 			!reflect.TypeOf((*context.Context)(nil)).Elem().AssignableTo(fn.In(0)) ||
 			!reflect.TypeOf(castParentType).AssignableTo(fn.In(1)) {
@@ -701,7 +701,7 @@ func (r *ChildReconciler) validate(ctx context.Context) error {
 	// validate DesiredChild function signature:
 	//     func(ctx context.Context, parent client.Object) (client.Object, error)
 	if r.DesiredChild == nil {
-		return fmt.Errorf("ChildReconciler must implement DesiredChild")
+		return fmt.Errorf("ChildReconciler %q must implement DesiredChild", r.Name)
 	} else {
 		fn := reflect.TypeOf(r.DesiredChild)
 		if fn.NumIn() != 2 || fn.NumOut() != 2 ||
@@ -709,21 +709,21 @@ func (r *ChildReconciler) validate(ctx context.Context) error {
 			!reflect.TypeOf(castParentType).AssignableTo(fn.In(1)) ||
 			!reflect.TypeOf(r.ChildType).AssignableTo(fn.Out(0)) ||
 			!reflect.TypeOf((*error)(nil)).Elem().AssignableTo(fn.Out(1)) {
-			return fmt.Errorf("ChildReconciler must implement DesiredChild: func(context.Context, %s) (%s, error), found: %s", reflect.TypeOf(castParentType), reflect.TypeOf(r.ChildType), fn)
+			return fmt.Errorf("ChildReconciler %q must implement DesiredChild: func(context.Context, %s) (%s, error), found: %s", r.Name, reflect.TypeOf(castParentType), reflect.TypeOf(r.ChildType), fn)
 		}
 	}
 
 	// validate ReflectChildStatusOnParent function signature:
 	//     func(parent, child client.Object, err error)
 	if r.ReflectChildStatusOnParent == nil {
-		return fmt.Errorf("ChildReconciler must implement ReflectChildStatusOnParent")
+		return fmt.Errorf("ChildReconciler %q must implement ReflectChildStatusOnParent", r.Name)
 	} else {
 		fn := reflect.TypeOf(r.ReflectChildStatusOnParent)
 		if fn.NumIn() != 3 || fn.NumOut() != 0 ||
 			!reflect.TypeOf(castParentType).AssignableTo(fn.In(0)) ||
 			!reflect.TypeOf(r.ChildType).AssignableTo(fn.In(1)) ||
 			!reflect.TypeOf((*error)(nil)).Elem().AssignableTo(fn.In(2)) {
-			return fmt.Errorf("ChildReconciler must implement ReflectChildStatusOnParent: func(%s, %s, error), found: %s", reflect.TypeOf(castParentType), reflect.TypeOf(r.ChildType), fn)
+			return fmt.Errorf("ChildReconciler %q must implement ReflectChildStatusOnParent: func(%s, %s, error), found: %s", r.Name, reflect.TypeOf(castParentType), reflect.TypeOf(r.ChildType), fn)
 		}
 	}
 
@@ -735,34 +735,34 @@ func (r *ChildReconciler) validate(ctx context.Context) error {
 		if fn.NumIn() != 2 || fn.NumOut() != 0 ||
 			!reflect.TypeOf(r.ChildType).AssignableTo(fn.In(0)) ||
 			!reflect.TypeOf(r.ChildType).AssignableTo(fn.In(1)) {
-			return fmt.Errorf("ChildReconciler must implement HarmonizeImmutableFields: nil | func(%s, %s), found: %s", reflect.TypeOf(r.ChildType), reflect.TypeOf(r.ChildType), fn)
+			return fmt.Errorf("ChildReconciler %q must implement HarmonizeImmutableFields: nil | func(%s, %s), found: %s", r.Name, reflect.TypeOf(r.ChildType), reflect.TypeOf(r.ChildType), fn)
 		}
 	}
 
 	// validate MergeBeforeUpdate function signature:
 	//     func(current, desired client.Object)
 	if r.MergeBeforeUpdate == nil {
-		return fmt.Errorf("ChildReconciler must implement MergeBeforeUpdate")
+		return fmt.Errorf("ChildReconciler %q must implement MergeBeforeUpdate", r.Name)
 	} else {
 		fn := reflect.TypeOf(r.MergeBeforeUpdate)
 		if fn.NumIn() != 2 || fn.NumOut() != 0 ||
 			!reflect.TypeOf(r.ChildType).AssignableTo(fn.In(0)) ||
 			!reflect.TypeOf(r.ChildType).AssignableTo(fn.In(1)) {
-			return fmt.Errorf("ChildReconciler must implement MergeBeforeUpdate: nil | func(%s, %s), found: %s", reflect.TypeOf(r.ChildType), reflect.TypeOf(r.ChildType), fn)
+			return fmt.Errorf("ChildReconciler %q must implement MergeBeforeUpdate: nil | func(%s, %s), found: %s", r.Name, reflect.TypeOf(r.ChildType), reflect.TypeOf(r.ChildType), fn)
 		}
 	}
 
 	// validate SemanticEquals function signature:
 	//     func(a1, a2 client.Object) bool
 	if r.SemanticEquals == nil {
-		return fmt.Errorf("ChildReconciler must implement SemanticEquals")
+		return fmt.Errorf("ChildReconciler %q must implement SemanticEquals", r.Name)
 	} else {
 		fn := reflect.TypeOf(r.SemanticEquals)
 		if fn.NumIn() != 2 || fn.NumOut() != 1 ||
 			!reflect.TypeOf(r.ChildType).AssignableTo(fn.In(0)) ||
 			!reflect.TypeOf(r.ChildType).AssignableTo(fn.In(1)) ||
 			fn.Out(0).Kind() != reflect.Bool {
-			return fmt.Errorf("ChildReconciler must implement SemanticEquals: nil | func(%s, %s) bool, found: %s", reflect.TypeOf(r.ChildType), reflect.TypeOf(r.ChildType), fn)
+			return fmt.Errorf("ChildReconciler %q must implement SemanticEquals: nil | func(%s, %s) bool, found: %s", r.Name, reflect.TypeOf(r.ChildType), reflect.TypeOf(r.ChildType), fn)
 		}
 	}
 
@@ -775,7 +775,7 @@ func (r *ChildReconciler) validate(ctx context.Context) error {
 			!reflect.TypeOf(castParentType).AssignableTo(fn.In(0)) ||
 			!reflect.TypeOf(r.ChildType).AssignableTo(fn.In(1)) ||
 			fn.Out(0).Kind() != reflect.Bool {
-			return fmt.Errorf("ChildReconciler must implement OurChild: nil | func(%s, %s) bool, found: %s", reflect.TypeOf(castParentType), reflect.TypeOf(r.ChildType), fn)
+			return fmt.Errorf("ChildReconciler %q must implement OurChild: nil | func(%s, %s) bool, found: %s", r.Name, reflect.TypeOf(castParentType), reflect.TypeOf(r.ChildType), fn)
 		}
 	}
 
@@ -786,7 +786,7 @@ func (r *ChildReconciler) validate(ctx context.Context) error {
 		fn := reflect.TypeOf(r.Sanitize)
 		if fn.NumIn() != 1 || fn.NumOut() != 1 ||
 			!reflect.TypeOf(r.ChildType).AssignableTo(fn.In(0)) {
-			return fmt.Errorf("ChildReconciler must implement Sanitize: nil | func(%s) interface{}, found: %s", reflect.TypeOf(r.ChildType), fn)
+			return fmt.Errorf("ChildReconciler %q must implement Sanitize: nil | func(%s) interface{}, found: %s", r.Name, reflect.TypeOf(r.ChildType), fn)
 		}
 	}
 

--- a/reconcilers/reconcilers.go
+++ b/reconcilers/reconcilers.go
@@ -690,12 +690,12 @@ func (r *ChildReconciler) validate(ctx context.Context) error {
 
 	// validate ChildType value
 	if r.ChildType == nil {
-		return fmt.Errorf("ChildType must be defined")
+		return fmt.Errorf("ChildReconciler %q must define ChildType", r.Name)
 	}
 
 	// validate ChildListType value
 	if r.ChildListType == nil {
-		return fmt.Errorf("ChildListType must be defined")
+		return fmt.Errorf("ChildReconciler %q must define ChildListType", r.Name)
 	}
 
 	// validate DesiredChild function signature:
@@ -748,7 +748,7 @@ func (r *ChildReconciler) validate(ctx context.Context) error {
 		if fn.NumIn() != 2 || fn.NumOut() != 0 ||
 			!reflect.TypeOf(r.ChildType).AssignableTo(fn.In(0)) ||
 			!reflect.TypeOf(r.ChildType).AssignableTo(fn.In(1)) {
-			return fmt.Errorf("ChildReconciler %q must implement MergeBeforeUpdate: nil | func(%s, %s), found: %s", r.Name, reflect.TypeOf(r.ChildType), reflect.TypeOf(r.ChildType), fn)
+			return fmt.Errorf("ChildReconciler %q must implement MergeBeforeUpdate: func(%s, %s), found: %s", r.Name, reflect.TypeOf(r.ChildType), reflect.TypeOf(r.ChildType), fn)
 		}
 	}
 
@@ -762,7 +762,7 @@ func (r *ChildReconciler) validate(ctx context.Context) error {
 			!reflect.TypeOf(r.ChildType).AssignableTo(fn.In(0)) ||
 			!reflect.TypeOf(r.ChildType).AssignableTo(fn.In(1)) ||
 			fn.Out(0).Kind() != reflect.Bool {
-			return fmt.Errorf("ChildReconciler %q must implement SemanticEquals: nil | func(%s, %s) bool, found: %s", r.Name, reflect.TypeOf(r.ChildType), reflect.TypeOf(r.ChildType), fn)
+			return fmt.Errorf("ChildReconciler %q must implement SemanticEquals: func(%s, %s) bool, found: %s", r.Name, reflect.TypeOf(r.ChildType), reflect.TypeOf(r.ChildType), fn)
 		}
 	}
 
@@ -1164,12 +1164,12 @@ func (r *CastParent) SetupWithManager(ctx context.Context, mgr ctrl.Manager, bld
 func (r *CastParent) validate(ctx context.Context) error {
 	// validate Type value
 	if r.Type == nil {
-		return fmt.Errorf("Type must be defined")
+		return fmt.Errorf("CastParent %q must define Type", r.Name)
 	}
 
 	// validate Reconciler value
 	if r.Reconciler == nil {
-		return fmt.Errorf("Reconciler must be defined")
+		return fmt.Errorf("CastParent %q must define Reconciler", r.Name)
 	}
 
 	return nil
@@ -1266,12 +1266,12 @@ func (r *WithConfig) SetupWithManager(ctx context.Context, mgr ctrl.Manager, bld
 func (r *WithConfig) validate(ctx context.Context) error {
 	// validate Config value
 	if r.Config == nil {
-		return fmt.Errorf("Config must be defined")
+		return fmt.Errorf("WithConfig %q must define Config", r.Name)
 	}
 
 	// validate Reconciler value
 	if r.Reconciler == nil {
-		return fmt.Errorf("Reconciler must be defined")
+		return fmt.Errorf("WithConfig %q must define Reconciler", r.Name)
 	}
 
 	return nil
@@ -1333,12 +1333,12 @@ func (r *WithFinalizer) SetupWithManager(ctx context.Context, mgr ctrl.Manager, 
 func (r *WithFinalizer) validate(ctx context.Context) error {
 	// validate Finalizer value
 	if r.Finalizer == "" {
-		return fmt.Errorf("Finalizer must be defined")
+		return fmt.Errorf("WithFinalizer %q must define Finalizer", r.Name)
 	}
 
 	// validate Reconciler value
 	if r.Reconciler == nil {
-		return fmt.Errorf("Reconciler must be defined")
+		return fmt.Errorf("WithFinalizer %q must define Reconciler", r.Name)
 	}
 
 	return nil

--- a/reconcilers/reconcilers_validate_test.go
+++ b/reconcilers/reconcilers_validate_test.go
@@ -25,8 +25,8 @@ func TestSyncReconciler_validate(t *testing.T) {
 		{
 			name:       "empty",
 			parent:     &corev1.ConfigMap{},
-			reconciler: &SyncReconciler{},
-			shouldErr:  "SyncReconciler must implement Sync",
+			reconciler: &SyncReconciler{Name: "empty"},
+			shouldErr:  `SyncReconciler "empty" must implement Sync`,
 		},
 		{
 			name:   "valid",
@@ -50,50 +50,55 @@ func TestSyncReconciler_validate(t *testing.T) {
 			name:   "Sync num in",
 			parent: &corev1.ConfigMap{},
 			reconciler: &SyncReconciler{
+				Name: "Sync num in",
 				Sync: func() error {
 					return nil
 				},
 			},
-			shouldErr: "SyncReconciler must implement Sync: func(context.Context, *v1.ConfigMap) error | func(context.Context, *v1.ConfigMap) (ctrl.Result, error), found: func() error",
+			shouldErr: `SyncReconciler "Sync num in" must implement Sync: func(context.Context, *v1.ConfigMap) error | func(context.Context, *v1.ConfigMap) (ctrl.Result, error), found: func() error`,
 		},
 		{
 			name:   "Sync in 1",
 			parent: &corev1.ConfigMap{},
 			reconciler: &SyncReconciler{
+				Name: "Sync in 1",
 				Sync: func(ctx context.Context, parent *corev1.Secret) error {
 					return nil
 				},
 			},
-			shouldErr: "SyncReconciler must implement Sync: func(context.Context, *v1.ConfigMap) error | func(context.Context, *v1.ConfigMap) (ctrl.Result, error), found: func(context.Context, *v1.Secret) error",
+			shouldErr: `SyncReconciler "Sync in 1" must implement Sync: func(context.Context, *v1.ConfigMap) error | func(context.Context, *v1.ConfigMap) (ctrl.Result, error), found: func(context.Context, *v1.Secret) error`,
 		},
 		{
 			name:   "Sync num out",
 			parent: &corev1.ConfigMap{},
 			reconciler: &SyncReconciler{
+				Name: "Sync num out",
 				Sync: func(ctx context.Context, parent *corev1.ConfigMap) {
 				},
 			},
-			shouldErr: "SyncReconciler must implement Sync: func(context.Context, *v1.ConfigMap) error | func(context.Context, *v1.ConfigMap) (ctrl.Result, error), found: func(context.Context, *v1.ConfigMap)",
+			shouldErr: `SyncReconciler "Sync num out" must implement Sync: func(context.Context, *v1.ConfigMap) error | func(context.Context, *v1.ConfigMap) (ctrl.Result, error), found: func(context.Context, *v1.ConfigMap)`,
 		},
 		{
 			name:   "Sync out 1",
 			parent: &corev1.ConfigMap{},
 			reconciler: &SyncReconciler{
+				Name: "Sync out 1",
 				Sync: func(ctx context.Context, parent *corev1.ConfigMap) string {
 					return ""
 				},
 			},
-			shouldErr: "SyncReconciler must implement Sync: func(context.Context, *v1.ConfigMap) error | func(context.Context, *v1.ConfigMap) (ctrl.Result, error), found: func(context.Context, *v1.ConfigMap) string",
+			shouldErr: `SyncReconciler "Sync out 1" must implement Sync: func(context.Context, *v1.ConfigMap) error | func(context.Context, *v1.ConfigMap) (ctrl.Result, error), found: func(context.Context, *v1.ConfigMap) string`,
 		},
 		{
 			name:   "Sync result out 1",
 			parent: &corev1.ConfigMap{},
 			reconciler: &SyncReconciler{
+				Name: "Sync result out 1",
 				Sync: func(ctx context.Context, parent *corev1.ConfigMap) (ctrl.Result, string) {
 					return ctrl.Result{}, ""
 				},
 			},
-			shouldErr: "SyncReconciler must implement Sync: func(context.Context, *v1.ConfigMap) error | func(context.Context, *v1.ConfigMap) (ctrl.Result, error), found: func(context.Context, *v1.ConfigMap) (reconcile.Result, string)",
+			shouldErr: `SyncReconciler "Sync result out 1" must implement Sync: func(context.Context, *v1.ConfigMap) error | func(context.Context, *v1.ConfigMap) (ctrl.Result, error), found: func(context.Context, *v1.ConfigMap) (reconcile.Result, string)`,
 		},
 		{
 			name:   "valid Finalize",
@@ -123,6 +128,7 @@ func TestSyncReconciler_validate(t *testing.T) {
 			name:   "Finalize num in",
 			parent: &corev1.ConfigMap{},
 			reconciler: &SyncReconciler{
+				Name: "Finalize num in",
 				Sync: func(ctx context.Context, parent *corev1.ConfigMap) error {
 					return nil
 				},
@@ -130,12 +136,13 @@ func TestSyncReconciler_validate(t *testing.T) {
 					return nil
 				},
 			},
-			shouldErr: "SyncReconciler must implement Finalize: nil | func(context.Context, *v1.ConfigMap) error | func(context.Context, *v1.ConfigMap) (ctrl.Result, error), found: func() error",
+			shouldErr: `SyncReconciler "Finalize num in" must implement Finalize: nil | func(context.Context, *v1.ConfigMap) error | func(context.Context, *v1.ConfigMap) (ctrl.Result, error), found: func() error`,
 		},
 		{
 			name:   "Finalize in 1",
 			parent: &corev1.ConfigMap{},
 			reconciler: &SyncReconciler{
+				Name: "Finalize in 1",
 				Sync: func(ctx context.Context, parent *corev1.ConfigMap) error {
 					return nil
 				},
@@ -143,24 +150,26 @@ func TestSyncReconciler_validate(t *testing.T) {
 					return nil
 				},
 			},
-			shouldErr: "SyncReconciler must implement Finalize: nil | func(context.Context, *v1.ConfigMap) error | func(context.Context, *v1.ConfigMap) (ctrl.Result, error), found: func(context.Context, *v1.Secret) error",
+			shouldErr: `SyncReconciler "Finalize in 1" must implement Finalize: nil | func(context.Context, *v1.ConfigMap) error | func(context.Context, *v1.ConfigMap) (ctrl.Result, error), found: func(context.Context, *v1.Secret) error`,
 		},
 		{
 			name:   "Finalize num out",
 			parent: &corev1.ConfigMap{},
 			reconciler: &SyncReconciler{
+				Name: "Finalize num out",
 				Sync: func(ctx context.Context, parent *corev1.ConfigMap) error {
 					return nil
 				},
 				Finalize: func(ctx context.Context, parent *corev1.ConfigMap) {
 				},
 			},
-			shouldErr: "SyncReconciler must implement Finalize: nil | func(context.Context, *v1.ConfigMap) error | func(context.Context, *v1.ConfigMap) (ctrl.Result, error), found: func(context.Context, *v1.ConfigMap)",
+			shouldErr: `SyncReconciler "Finalize num out" must implement Finalize: nil | func(context.Context, *v1.ConfigMap) error | func(context.Context, *v1.ConfigMap) (ctrl.Result, error), found: func(context.Context, *v1.ConfigMap)`,
 		},
 		{
 			name:   "Finalize out 1",
 			parent: &corev1.ConfigMap{},
 			reconciler: &SyncReconciler{
+				Name: "Finalize out 1",
 				Sync: func(ctx context.Context, parent *corev1.ConfigMap) error {
 					return nil
 				},
@@ -168,12 +177,13 @@ func TestSyncReconciler_validate(t *testing.T) {
 					return ""
 				},
 			},
-			shouldErr: "SyncReconciler must implement Finalize: nil | func(context.Context, *v1.ConfigMap) error | func(context.Context, *v1.ConfigMap) (ctrl.Result, error), found: func(context.Context, *v1.ConfigMap) string",
+			shouldErr: `SyncReconciler "Finalize out 1" must implement Finalize: nil | func(context.Context, *v1.ConfigMap) error | func(context.Context, *v1.ConfigMap) (ctrl.Result, error), found: func(context.Context, *v1.ConfigMap) string`,
 		},
 		{
 			name:   "Finalize result out 1",
 			parent: &corev1.ConfigMap{},
 			reconciler: &SyncReconciler{
+				Name: "Finalize result out 1",
 				Sync: func(ctx context.Context, parent *corev1.ConfigMap) error {
 					return nil
 				},
@@ -181,7 +191,7 @@ func TestSyncReconciler_validate(t *testing.T) {
 					return ctrl.Result{}, ""
 				},
 			},
-			shouldErr: "SyncReconciler must implement Finalize: nil | func(context.Context, *v1.ConfigMap) error | func(context.Context, *v1.ConfigMap) (ctrl.Result, error), found: func(context.Context, *v1.ConfigMap) (reconcile.Result, string)",
+			shouldErr: `SyncReconciler "Finalize result out 1" must implement Finalize: nil | func(context.Context, *v1.ConfigMap) error | func(context.Context, *v1.ConfigMap) (ctrl.Result, error), found: func(context.Context, *v1.ConfigMap) (reconcile.Result, string)`,
 		},
 	}
 
@@ -251,6 +261,7 @@ func TestChildReconciler_validate(t *testing.T) {
 			name:   "DesiredChild missing",
 			parent: &corev1.ConfigMap{},
 			reconciler: &ChildReconciler{
+				Name:          "DesiredChild missing",
 				ChildType:     &corev1.Pod{},
 				ChildListType: &corev1.PodList{},
 				// DesiredChild:               func(ctx context.Context, parent *corev1.ConfigMap) (*corev1.Pod, error) { return nil, nil },
@@ -258,12 +269,13 @@ func TestChildReconciler_validate(t *testing.T) {
 				MergeBeforeUpdate:          func(current, desired *corev1.Pod) {},
 				SemanticEquals:             func(a1, a2 *corev1.Pod) bool { return false },
 			},
-			shouldErr: "ChildReconciler must implement DesiredChild",
+			shouldErr: `ChildReconciler "DesiredChild missing" must implement DesiredChild`,
 		},
 		{
 			name:   "DesiredChild num in",
 			parent: &corev1.ConfigMap{},
 			reconciler: &ChildReconciler{
+				Name:                       "DesiredChild num in",
 				ChildType:                  &corev1.Pod{},
 				ChildListType:              &corev1.PodList{},
 				DesiredChild:               func() (*corev1.Pod, error) { return nil, nil },
@@ -271,12 +283,13 @@ func TestChildReconciler_validate(t *testing.T) {
 				MergeBeforeUpdate:          func(current, desired *corev1.Pod) {},
 				SemanticEquals:             func(a1, a2 *corev1.Pod) bool { return false },
 			},
-			shouldErr: "ChildReconciler must implement DesiredChild: func(context.Context, *v1.ConfigMap) (*v1.Pod, error), found: func() (*v1.Pod, error)",
+			shouldErr: `ChildReconciler "DesiredChild num in" must implement DesiredChild: func(context.Context, *v1.ConfigMap) (*v1.Pod, error), found: func() (*v1.Pod, error)`,
 		},
 		{
 			name:   "DesiredChild in 0",
 			parent: &corev1.ConfigMap{},
 			reconciler: &ChildReconciler{
+				Name:                       "DesiredChild in 0",
 				ChildType:                  &corev1.Pod{},
 				ChildListType:              &corev1.PodList{},
 				DesiredChild:               func(ctx string, parent *corev1.ConfigMap) (*corev1.Pod, error) { return nil, nil },
@@ -284,12 +297,13 @@ func TestChildReconciler_validate(t *testing.T) {
 				MergeBeforeUpdate:          func(current, desired *corev1.Pod) {},
 				SemanticEquals:             func(a1, a2 *corev1.Pod) bool { return false },
 			},
-			shouldErr: "ChildReconciler must implement DesiredChild: func(context.Context, *v1.ConfigMap) (*v1.Pod, error), found: func(string, *v1.ConfigMap) (*v1.Pod, error)",
+			shouldErr: `ChildReconciler "DesiredChild in 0" must implement DesiredChild: func(context.Context, *v1.ConfigMap) (*v1.Pod, error), found: func(string, *v1.ConfigMap) (*v1.Pod, error)`,
 		},
 		{
 			name:   "DesiredChild in 1",
 			parent: &corev1.ConfigMap{},
 			reconciler: &ChildReconciler{
+				Name:                       "DesiredChild in 1",
 				ChildType:                  &corev1.Pod{},
 				ChildListType:              &corev1.PodList{},
 				DesiredChild:               func(ctx context.Context, parent *corev1.Secret) (*corev1.Pod, error) { return nil, nil },
@@ -297,12 +311,13 @@ func TestChildReconciler_validate(t *testing.T) {
 				MergeBeforeUpdate:          func(current, desired *corev1.Pod) {},
 				SemanticEquals:             func(a1, a2 *corev1.Pod) bool { return false },
 			},
-			shouldErr: "ChildReconciler must implement DesiredChild: func(context.Context, *v1.ConfigMap) (*v1.Pod, error), found: func(context.Context, *v1.Secret) (*v1.Pod, error)",
+			shouldErr: `ChildReconciler "DesiredChild in 1" must implement DesiredChild: func(context.Context, *v1.ConfigMap) (*v1.Pod, error), found: func(context.Context, *v1.Secret) (*v1.Pod, error)`,
 		},
 		{
 			name:   "DesiredChild num out",
 			parent: &corev1.ConfigMap{},
 			reconciler: &ChildReconciler{
+				Name:                       "DesiredChild num out",
 				ChildType:                  &corev1.Pod{},
 				ChildListType:              &corev1.PodList{},
 				DesiredChild:               func(ctx context.Context, parent *corev1.ConfigMap) {},
@@ -310,12 +325,13 @@ func TestChildReconciler_validate(t *testing.T) {
 				MergeBeforeUpdate:          func(current, desired *corev1.Pod) {},
 				SemanticEquals:             func(a1, a2 *corev1.Pod) bool { return false },
 			},
-			shouldErr: "ChildReconciler must implement DesiredChild: func(context.Context, *v1.ConfigMap) (*v1.Pod, error), found: func(context.Context, *v1.ConfigMap)",
+			shouldErr: `ChildReconciler "DesiredChild num out" must implement DesiredChild: func(context.Context, *v1.ConfigMap) (*v1.Pod, error), found: func(context.Context, *v1.ConfigMap)`,
 		},
 		{
 			name:   "DesiredChild out 0",
 			parent: &corev1.ConfigMap{},
 			reconciler: &ChildReconciler{
+				Name:                       "DesiredChild out 0",
 				ChildType:                  &corev1.Pod{},
 				ChildListType:              &corev1.PodList{},
 				DesiredChild:               func(ctx context.Context, parent *corev1.ConfigMap) (*corev1.Secret, error) { return nil, nil },
@@ -323,12 +339,13 @@ func TestChildReconciler_validate(t *testing.T) {
 				MergeBeforeUpdate:          func(current, desired *corev1.Pod) {},
 				SemanticEquals:             func(a1, a2 *corev1.Pod) bool { return false },
 			},
-			shouldErr: "ChildReconciler must implement DesiredChild: func(context.Context, *v1.ConfigMap) (*v1.Pod, error), found: func(context.Context, *v1.ConfigMap) (*v1.Secret, error)",
+			shouldErr: `ChildReconciler "DesiredChild out 0" must implement DesiredChild: func(context.Context, *v1.ConfigMap) (*v1.Pod, error), found: func(context.Context, *v1.ConfigMap) (*v1.Secret, error)`,
 		},
 		{
 			name:   "DesiredChild out 1",
 			parent: &corev1.ConfigMap{},
 			reconciler: &ChildReconciler{
+				Name:                       "DesiredChild out 1",
 				ChildType:                  &corev1.Pod{},
 				ChildListType:              &corev1.PodList{},
 				DesiredChild:               func(ctx context.Context, parent *corev1.ConfigMap) (*corev1.Pod, string) { return nil, "" },
@@ -336,12 +353,13 @@ func TestChildReconciler_validate(t *testing.T) {
 				MergeBeforeUpdate:          func(current, desired *corev1.Pod) {},
 				SemanticEquals:             func(a1, a2 *corev1.Pod) bool { return false },
 			},
-			shouldErr: "ChildReconciler must implement DesiredChild: func(context.Context, *v1.ConfigMap) (*v1.Pod, error), found: func(context.Context, *v1.ConfigMap) (*v1.Pod, string)",
+			shouldErr: `ChildReconciler "DesiredChild out 1" must implement DesiredChild: func(context.Context, *v1.ConfigMap) (*v1.Pod, error), found: func(context.Context, *v1.ConfigMap) (*v1.Pod, string)`,
 		},
 		{
 			name:   "ReflectChildStatusOnParent missing",
 			parent: &corev1.ConfigMap{},
 			reconciler: &ChildReconciler{
+				Name:          "ReflectChildStatusOnParent missing",
 				ChildType:     &corev1.Pod{},
 				ChildListType: &corev1.PodList{},
 				DesiredChild:  func(ctx context.Context, parent *corev1.ConfigMap) (*corev1.Pod, error) { return nil, nil },
@@ -349,12 +367,13 @@ func TestChildReconciler_validate(t *testing.T) {
 				MergeBeforeUpdate: func(current, desired *corev1.Pod) {},
 				SemanticEquals:    func(a1, a2 *corev1.Pod) bool { return false },
 			},
-			shouldErr: "ChildReconciler must implement ReflectChildStatusOnParent",
+			shouldErr: `ChildReconciler "ReflectChildStatusOnParent missing" must implement ReflectChildStatusOnParent`,
 		},
 		{
 			name:   "ReflectChildStatusOnParent num in",
 			parent: &corev1.ConfigMap{},
 			reconciler: &ChildReconciler{
+				Name:                       "ReflectChildStatusOnParent num in",
 				ChildType:                  &corev1.Pod{},
 				ChildListType:              &corev1.PodList{},
 				DesiredChild:               func(ctx context.Context, parent *corev1.ConfigMap) (*corev1.Pod, error) { return nil, nil },
@@ -362,12 +381,13 @@ func TestChildReconciler_validate(t *testing.T) {
 				MergeBeforeUpdate:          func(current, desired *corev1.Pod) {},
 				SemanticEquals:             func(a1, a2 *corev1.Pod) bool { return false },
 			},
-			shouldErr: "ChildReconciler must implement ReflectChildStatusOnParent: func(*v1.ConfigMap, *v1.Pod, error), found: func()",
+			shouldErr: `ChildReconciler "ReflectChildStatusOnParent num in" must implement ReflectChildStatusOnParent: func(*v1.ConfigMap, *v1.Pod, error), found: func()`,
 		},
 		{
 			name:   "ReflectChildStatusOnParent in 0",
 			parent: &corev1.ConfigMap{},
 			reconciler: &ChildReconciler{
+				Name:                       "ReflectChildStatusOnParent in 0",
 				ChildType:                  &corev1.Pod{},
 				ChildListType:              &corev1.PodList{},
 				DesiredChild:               func(ctx context.Context, parent *corev1.ConfigMap) (*corev1.Pod, error) { return nil, nil },
@@ -375,12 +395,13 @@ func TestChildReconciler_validate(t *testing.T) {
 				MergeBeforeUpdate:          func(current, desired *corev1.Pod) {},
 				SemanticEquals:             func(a1, a2 *corev1.Pod) bool { return false },
 			},
-			shouldErr: "ChildReconciler must implement ReflectChildStatusOnParent: func(*v1.ConfigMap, *v1.Pod, error), found: func(*v1.Secret, *v1.Pod, error)",
+			shouldErr: `ChildReconciler "ReflectChildStatusOnParent in 0" must implement ReflectChildStatusOnParent: func(*v1.ConfigMap, *v1.Pod, error), found: func(*v1.Secret, *v1.Pod, error)`,
 		},
 		{
 			name:   "ReflectChildStatusOnParent in 1",
 			parent: &corev1.ConfigMap{},
 			reconciler: &ChildReconciler{
+				Name:                       "ReflectChildStatusOnParent in 1",
 				ChildType:                  &corev1.Pod{},
 				ChildListType:              &corev1.PodList{},
 				DesiredChild:               func(ctx context.Context, parent *corev1.ConfigMap) (*corev1.Pod, error) { return nil, nil },
@@ -388,12 +409,13 @@ func TestChildReconciler_validate(t *testing.T) {
 				MergeBeforeUpdate:          func(current, desired *corev1.Pod) {},
 				SemanticEquals:             func(a1, a2 *corev1.Pod) bool { return false },
 			},
-			shouldErr: "ChildReconciler must implement ReflectChildStatusOnParent: func(*v1.ConfigMap, *v1.Pod, error), found: func(*v1.ConfigMap, *v1.Secret, error)",
+			shouldErr: `ChildReconciler "ReflectChildStatusOnParent in 1" must implement ReflectChildStatusOnParent: func(*v1.ConfigMap, *v1.Pod, error), found: func(*v1.ConfigMap, *v1.Secret, error)`,
 		},
 		{
 			name:   "ReflectChildStatusOnParent in 2",
 			parent: &corev1.ConfigMap{},
 			reconciler: &ChildReconciler{
+				Name:                       "ReflectChildStatusOnParent in 2",
 				ChildType:                  &corev1.Pod{},
 				ChildListType:              &corev1.PodList{},
 				DesiredChild:               func(ctx context.Context, parent *corev1.ConfigMap) (*corev1.Pod, error) { return nil, nil },
@@ -401,12 +423,13 @@ func TestChildReconciler_validate(t *testing.T) {
 				MergeBeforeUpdate:          func(current, desired *corev1.Pod) {},
 				SemanticEquals:             func(a1, a2 *corev1.Pod) bool { return false },
 			},
-			shouldErr: "ChildReconciler must implement ReflectChildStatusOnParent: func(*v1.ConfigMap, *v1.Pod, error), found: func(*v1.ConfigMap, *v1.Pod, context.Context)",
+			shouldErr: `ChildReconciler "ReflectChildStatusOnParent in 2" must implement ReflectChildStatusOnParent: func(*v1.ConfigMap, *v1.Pod, error), found: func(*v1.ConfigMap, *v1.Pod, context.Context)`,
 		},
 		{
 			name:   "ReflectChildStatusOnParent num out",
 			parent: &corev1.ConfigMap{},
 			reconciler: &ChildReconciler{
+				Name:                       "ReflectChildStatusOnParent num out",
 				ChildType:                  &corev1.Pod{},
 				ChildListType:              &corev1.PodList{},
 				DesiredChild:               func(ctx context.Context, parent *corev1.ConfigMap) (*corev1.Pod, error) { return nil, nil },
@@ -414,12 +437,13 @@ func TestChildReconciler_validate(t *testing.T) {
 				MergeBeforeUpdate:          func(current, desired *corev1.Pod) {},
 				SemanticEquals:             func(a1, a2 *corev1.Pod) bool { return false },
 			},
-			shouldErr: "ChildReconciler must implement ReflectChildStatusOnParent: func(*v1.ConfigMap, *v1.Pod, error), found: func(*v1.ConfigMap, *v1.Pod, error) error",
+			shouldErr: `ChildReconciler "ReflectChildStatusOnParent num out" must implement ReflectChildStatusOnParent: func(*v1.ConfigMap, *v1.Pod, error), found: func(*v1.ConfigMap, *v1.Pod, error) error`,
 		},
 		{
 			name:   "MergeBeforeUpdate missing",
 			parent: &corev1.ConfigMap{},
 			reconciler: &ChildReconciler{
+				Name:                       "MergeBeforeUpdate missing",
 				ChildType:                  &corev1.Pod{},
 				ChildListType:              &corev1.PodList{},
 				DesiredChild:               func(ctx context.Context, parent *corev1.ConfigMap) (*corev1.Pod, error) { return nil, nil },
@@ -427,12 +451,13 @@ func TestChildReconciler_validate(t *testing.T) {
 				// MergeBeforeUpdate:          func(current, desired *corev1.Pod) {},
 				SemanticEquals: func(a1, a2 *corev1.Pod) bool { return false },
 			},
-			shouldErr: "ChildReconciler must implement MergeBeforeUpdate",
+			shouldErr: `ChildReconciler "MergeBeforeUpdate missing" must implement MergeBeforeUpdate`,
 		},
 		{
 			name:   "MergeBeforeUpdate num in",
 			parent: &corev1.ConfigMap{},
 			reconciler: &ChildReconciler{
+				Name:                       "MergeBeforeUpdate num in",
 				ChildType:                  &corev1.Pod{},
 				ChildListType:              &corev1.PodList{},
 				DesiredChild:               func(ctx context.Context, parent *corev1.ConfigMap) (*corev1.Pod, error) { return nil, nil },
@@ -440,12 +465,13 @@ func TestChildReconciler_validate(t *testing.T) {
 				MergeBeforeUpdate:          func() {},
 				SemanticEquals:             func(a1, a2 *corev1.Pod) bool { return false },
 			},
-			shouldErr: "ChildReconciler must implement MergeBeforeUpdate: nil | func(*v1.Pod, *v1.Pod), found: func()",
+			shouldErr: `ChildReconciler "MergeBeforeUpdate num in" must implement MergeBeforeUpdate: nil | func(*v1.Pod, *v1.Pod), found: func()`,
 		},
 		{
 			name:   "MergeBeforeUpdate in 0",
 			parent: &corev1.ConfigMap{},
 			reconciler: &ChildReconciler{
+				Name:                       "MergeBeforeUpdate in 0",
 				ChildType:                  &corev1.Pod{},
 				ChildListType:              &corev1.PodList{},
 				DesiredChild:               func(ctx context.Context, parent *corev1.ConfigMap) (*corev1.Pod, error) { return nil, nil },
@@ -453,12 +479,13 @@ func TestChildReconciler_validate(t *testing.T) {
 				MergeBeforeUpdate:          func(current *corev1.Secret, desired *corev1.Pod) {},
 				SemanticEquals:             func(a1, a2 *corev1.Pod) bool { return false },
 			},
-			shouldErr: "ChildReconciler must implement MergeBeforeUpdate: nil | func(*v1.Pod, *v1.Pod), found: func(*v1.Secret, *v1.Pod)",
+			shouldErr: `ChildReconciler "MergeBeforeUpdate in 0" must implement MergeBeforeUpdate: nil | func(*v1.Pod, *v1.Pod), found: func(*v1.Secret, *v1.Pod)`,
 		},
 		{
 			name:   "MergeBeforeUpdate in 1",
 			parent: &corev1.ConfigMap{},
 			reconciler: &ChildReconciler{
+				Name:                       "MergeBeforeUpdate in 1",
 				ChildType:                  &corev1.Pod{},
 				ChildListType:              &corev1.PodList{},
 				DesiredChild:               func(ctx context.Context, parent *corev1.ConfigMap) (*corev1.Pod, error) { return nil, nil },
@@ -466,12 +493,13 @@ func TestChildReconciler_validate(t *testing.T) {
 				MergeBeforeUpdate:          func(current *corev1.Pod, desired *corev1.Secret) {},
 				SemanticEquals:             func(a1, a2 *corev1.Pod) bool { return false },
 			},
-			shouldErr: "ChildReconciler must implement MergeBeforeUpdate: nil | func(*v1.Pod, *v1.Pod), found: func(*v1.Pod, *v1.Secret)",
+			shouldErr: `ChildReconciler "MergeBeforeUpdate in 1" must implement MergeBeforeUpdate: nil | func(*v1.Pod, *v1.Pod), found: func(*v1.Pod, *v1.Secret)`,
 		},
 		{
 			name:   "MergeBeforeUpdate num out",
 			parent: &corev1.ConfigMap{},
 			reconciler: &ChildReconciler{
+				Name:                       "MergeBeforeUpdate num out",
 				ChildType:                  &corev1.Pod{},
 				ChildListType:              &corev1.PodList{},
 				DesiredChild:               func(ctx context.Context, parent *corev1.ConfigMap) (*corev1.Pod, error) { return nil, nil },
@@ -479,12 +507,13 @@ func TestChildReconciler_validate(t *testing.T) {
 				MergeBeforeUpdate:          func(current, desired *corev1.Pod) error { return nil },
 				SemanticEquals:             func(a1, a2 *corev1.Pod) bool { return false },
 			},
-			shouldErr: "ChildReconciler must implement MergeBeforeUpdate: nil | func(*v1.Pod, *v1.Pod), found: func(*v1.Pod, *v1.Pod) error",
+			shouldErr: `ChildReconciler "MergeBeforeUpdate num out" must implement MergeBeforeUpdate: nil | func(*v1.Pod, *v1.Pod), found: func(*v1.Pod, *v1.Pod) error`,
 		},
 		{
 			name:   "SemanticEquals missing",
 			parent: &corev1.ConfigMap{},
 			reconciler: &ChildReconciler{
+				Name:                       "SemanticEquals missing",
 				ChildType:                  &corev1.Pod{},
 				ChildListType:              &corev1.PodList{},
 				DesiredChild:               func(ctx context.Context, parent *corev1.ConfigMap) (*corev1.Pod, error) { return nil, nil },
@@ -492,12 +521,13 @@ func TestChildReconciler_validate(t *testing.T) {
 				MergeBeforeUpdate:          func(current, desired *corev1.Pod) {},
 				// SemanticEquals:             func(a1, a2 *corev1.Pod) bool { return false },
 			},
-			shouldErr: "ChildReconciler must implement SemanticEquals",
+			shouldErr: `ChildReconciler "SemanticEquals missing" must implement SemanticEquals`,
 		},
 		{
 			name:   "SemanticEquals num in",
 			parent: &corev1.ConfigMap{},
 			reconciler: &ChildReconciler{
+				Name:                       "SemanticEquals num in",
 				ChildType:                  &corev1.Pod{},
 				ChildListType:              &corev1.PodList{},
 				DesiredChild:               func(ctx context.Context, parent *corev1.ConfigMap) (*corev1.Pod, error) { return nil, nil },
@@ -505,12 +535,13 @@ func TestChildReconciler_validate(t *testing.T) {
 				MergeBeforeUpdate:          func(current, desired *corev1.Pod) {},
 				SemanticEquals:             func() bool { return false },
 			},
-			shouldErr: "ChildReconciler must implement SemanticEquals: nil | func(*v1.Pod, *v1.Pod) bool, found: func() bool",
+			shouldErr: `ChildReconciler "SemanticEquals num in" must implement SemanticEquals: nil | func(*v1.Pod, *v1.Pod) bool, found: func() bool`,
 		},
 		{
 			name:   "SemanticEquals in 0",
 			parent: &corev1.ConfigMap{},
 			reconciler: &ChildReconciler{
+				Name:                       "SemanticEquals in 0",
 				ChildType:                  &corev1.Pod{},
 				ChildListType:              &corev1.PodList{},
 				DesiredChild:               func(ctx context.Context, parent *corev1.ConfigMap) (*corev1.Pod, error) { return nil, nil },
@@ -518,12 +549,13 @@ func TestChildReconciler_validate(t *testing.T) {
 				MergeBeforeUpdate:          func(current, desired *corev1.Pod) {},
 				SemanticEquals:             func(a1 *corev1.Secret, a2 *corev1.Pod) bool { return false },
 			},
-			shouldErr: "ChildReconciler must implement SemanticEquals: nil | func(*v1.Pod, *v1.Pod) bool, found: func(*v1.Secret, *v1.Pod) bool",
+			shouldErr: `ChildReconciler "SemanticEquals in 0" must implement SemanticEquals: nil | func(*v1.Pod, *v1.Pod) bool, found: func(*v1.Secret, *v1.Pod) bool`,
 		},
 		{
 			name:   "SemanticEquals in 1",
 			parent: &corev1.ConfigMap{},
 			reconciler: &ChildReconciler{
+				Name:                       "SemanticEquals in 1",
 				ChildType:                  &corev1.Pod{},
 				ChildListType:              &corev1.PodList{},
 				DesiredChild:               func(ctx context.Context, parent *corev1.ConfigMap) (*corev1.Pod, error) { return nil, nil },
@@ -531,12 +563,13 @@ func TestChildReconciler_validate(t *testing.T) {
 				MergeBeforeUpdate:          func(current, desired *corev1.Pod) {},
 				SemanticEquals:             func(a1 *corev1.Pod, a2 *corev1.Secret) bool { return false },
 			},
-			shouldErr: "ChildReconciler must implement SemanticEquals: nil | func(*v1.Pod, *v1.Pod) bool, found: func(*v1.Pod, *v1.Secret) bool",
+			shouldErr: `ChildReconciler "SemanticEquals in 1" must implement SemanticEquals: nil | func(*v1.Pod, *v1.Pod) bool, found: func(*v1.Pod, *v1.Secret) bool`,
 		},
 		{
 			name:   "SemanticEquals num out",
 			parent: &corev1.ConfigMap{},
 			reconciler: &ChildReconciler{
+				Name:                       "SemanticEquals num out",
 				ChildType:                  &corev1.Pod{},
 				ChildListType:              &corev1.PodList{},
 				DesiredChild:               func(ctx context.Context, parent *corev1.ConfigMap) (*corev1.Pod, error) { return nil, nil },
@@ -544,12 +577,13 @@ func TestChildReconciler_validate(t *testing.T) {
 				MergeBeforeUpdate:          func(current, desired *corev1.Pod) {},
 				SemanticEquals:             func(a1, a2 *corev1.Pod) {},
 			},
-			shouldErr: "ChildReconciler must implement SemanticEquals: nil | func(*v1.Pod, *v1.Pod) bool, found: func(*v1.Pod, *v1.Pod)",
+			shouldErr: `ChildReconciler "SemanticEquals num out" must implement SemanticEquals: nil | func(*v1.Pod, *v1.Pod) bool, found: func(*v1.Pod, *v1.Pod)`,
 		},
 		{
 			name:   "SemanticEquals out 0",
 			parent: &corev1.ConfigMap{},
 			reconciler: &ChildReconciler{
+				Name:                       "SemanticEquals out 0",
 				ChildType:                  &corev1.Pod{},
 				ChildListType:              &corev1.PodList{},
 				DesiredChild:               func(ctx context.Context, parent *corev1.ConfigMap) (*corev1.Pod, error) { return nil, nil },
@@ -557,7 +591,7 @@ func TestChildReconciler_validate(t *testing.T) {
 				MergeBeforeUpdate:          func(current, desired *corev1.Pod) {},
 				SemanticEquals:             func(a1, a2 *corev1.Pod) error { return nil },
 			},
-			shouldErr: "ChildReconciler must implement SemanticEquals: nil | func(*v1.Pod, *v1.Pod) bool, found: func(*v1.Pod, *v1.Pod) error",
+			shouldErr: `ChildReconciler "SemanticEquals out 0" must implement SemanticEquals: nil | func(*v1.Pod, *v1.Pod) bool, found: func(*v1.Pod, *v1.Pod) error`,
 		},
 		{
 			name:   "HarmonizeImmutableFields",
@@ -576,6 +610,7 @@ func TestChildReconciler_validate(t *testing.T) {
 			name:   "HarmonizeImmutableFields num in",
 			parent: &corev1.ConfigMap{},
 			reconciler: &ChildReconciler{
+				Name:                       "HarmonizeImmutableFields num in",
 				ChildType:                  &corev1.Pod{},
 				ChildListType:              &corev1.PodList{},
 				DesiredChild:               func(ctx context.Context, parent *corev1.ConfigMap) (*corev1.Pod, error) { return nil, nil },
@@ -584,12 +619,13 @@ func TestChildReconciler_validate(t *testing.T) {
 				SemanticEquals:             func(a1, a2 *corev1.Pod) bool { return false },
 				HarmonizeImmutableFields:   func() {},
 			},
-			shouldErr: "ChildReconciler must implement HarmonizeImmutableFields: nil | func(*v1.Pod, *v1.Pod), found: func()",
+			shouldErr: `ChildReconciler "HarmonizeImmutableFields num in" must implement HarmonizeImmutableFields: nil | func(*v1.Pod, *v1.Pod), found: func()`,
 		},
 		{
 			name:   "HarmonizeImmutableFields in 0",
 			parent: &corev1.ConfigMap{},
 			reconciler: &ChildReconciler{
+				Name:                       "HarmonizeImmutableFields in 0",
 				ChildType:                  &corev1.Pod{},
 				ChildListType:              &corev1.PodList{},
 				DesiredChild:               func(ctx context.Context, parent *corev1.ConfigMap) (*corev1.Pod, error) { return nil, nil },
@@ -598,12 +634,13 @@ func TestChildReconciler_validate(t *testing.T) {
 				SemanticEquals:             func(a1, a2 *corev1.Pod) bool { return false },
 				HarmonizeImmutableFields:   func(current *corev1.Secret, desired *corev1.Pod) {},
 			},
-			shouldErr: "ChildReconciler must implement HarmonizeImmutableFields: nil | func(*v1.Pod, *v1.Pod), found: func(*v1.Secret, *v1.Pod)",
+			shouldErr: `ChildReconciler "HarmonizeImmutableFields in 0" must implement HarmonizeImmutableFields: nil | func(*v1.Pod, *v1.Pod), found: func(*v1.Secret, *v1.Pod)`,
 		},
 		{
 			name:   "HarmonizeImmutableFields in 1",
 			parent: &corev1.ConfigMap{},
 			reconciler: &ChildReconciler{
+				Name:                       "HarmonizeImmutableFields in 1",
 				ChildType:                  &corev1.Pod{},
 				ChildListType:              &corev1.PodList{},
 				DesiredChild:               func(ctx context.Context, parent *corev1.ConfigMap) (*corev1.Pod, error) { return nil, nil },
@@ -612,12 +649,13 @@ func TestChildReconciler_validate(t *testing.T) {
 				SemanticEquals:             func(a1, a2 *corev1.Pod) bool { return false },
 				HarmonizeImmutableFields:   func(current *corev1.Pod, desired *corev1.Secret) {},
 			},
-			shouldErr: "ChildReconciler must implement HarmonizeImmutableFields: nil | func(*v1.Pod, *v1.Pod), found: func(*v1.Pod, *v1.Secret)",
+			shouldErr: `ChildReconciler "HarmonizeImmutableFields in 1" must implement HarmonizeImmutableFields: nil | func(*v1.Pod, *v1.Pod), found: func(*v1.Pod, *v1.Secret)`,
 		},
 		{
 			name:   "HarmonizeImmutableFields num out",
 			parent: &corev1.ConfigMap{},
 			reconciler: &ChildReconciler{
+				Name:                       "HarmonizeImmutableFields num out",
 				ChildType:                  &corev1.Pod{},
 				ChildListType:              &corev1.PodList{},
 				DesiredChild:               func(ctx context.Context, parent *corev1.ConfigMap) (*corev1.Pod, error) { return nil, nil },
@@ -626,7 +664,7 @@ func TestChildReconciler_validate(t *testing.T) {
 				SemanticEquals:             func(a1, a2 *corev1.Pod) bool { return false },
 				HarmonizeImmutableFields:   func(current, desired *corev1.Pod) error { return nil },
 			},
-			shouldErr: "ChildReconciler must implement HarmonizeImmutableFields: nil | func(*v1.Pod, *v1.Pod), found: func(*v1.Pod, *v1.Pod) error",
+			shouldErr: `ChildReconciler "HarmonizeImmutableFields num out" must implement HarmonizeImmutableFields: nil | func(*v1.Pod, *v1.Pod), found: func(*v1.Pod, *v1.Pod) error`,
 		},
 		{
 			name:   "OurChild",
@@ -645,6 +683,7 @@ func TestChildReconciler_validate(t *testing.T) {
 			name:   "OurChild num in",
 			parent: &corev1.ConfigMap{},
 			reconciler: &ChildReconciler{
+				Name:                       "OurChild num in",
 				ChildType:                  &corev1.Pod{},
 				ChildListType:              &corev1.PodList{},
 				DesiredChild:               func(ctx context.Context, parent *corev1.ConfigMap) (*corev1.Pod, error) { return nil, nil },
@@ -653,12 +692,13 @@ func TestChildReconciler_validate(t *testing.T) {
 				SemanticEquals:             func(a1, a2 *corev1.Pod) bool { return false },
 				OurChild:                   func() bool { return false },
 			},
-			shouldErr: "ChildReconciler must implement OurChild: nil | func(*v1.ConfigMap, *v1.Pod) bool, found: func() bool",
+			shouldErr: `ChildReconciler "OurChild num in" must implement OurChild: nil | func(*v1.ConfigMap, *v1.Pod) bool, found: func() bool`,
 		},
 		{
 			name:   "OurChild in 1",
 			parent: &corev1.ConfigMap{},
 			reconciler: &ChildReconciler{
+				Name:                       "OurChild in 1",
 				ChildType:                  &corev1.Pod{},
 				ChildListType:              &corev1.PodList{},
 				DesiredChild:               func(ctx context.Context, parent *corev1.ConfigMap) (*corev1.Pod, error) { return nil, nil },
@@ -667,12 +707,13 @@ func TestChildReconciler_validate(t *testing.T) {
 				SemanticEquals:             func(a1, a2 *corev1.Pod) bool { return false },
 				OurChild:                   func(parent *corev1.ConfigMap, child *corev1.Secret) bool { return false },
 			},
-			shouldErr: "ChildReconciler must implement OurChild: nil | func(*v1.ConfigMap, *v1.Pod) bool, found: func(*v1.ConfigMap, *v1.Secret) bool",
+			shouldErr: `ChildReconciler "OurChild in 1" must implement OurChild: nil | func(*v1.ConfigMap, *v1.Pod) bool, found: func(*v1.ConfigMap, *v1.Secret) bool`,
 		},
 		{
 			name:   "OurChild in 2",
 			parent: &corev1.ConfigMap{},
 			reconciler: &ChildReconciler{
+				Name:                       "OurChild in 2",
 				ChildType:                  &corev1.Pod{},
 				ChildListType:              &corev1.PodList{},
 				DesiredChild:               func(ctx context.Context, parent *corev1.ConfigMap) (*corev1.Pod, error) { return nil, nil },
@@ -681,12 +722,13 @@ func TestChildReconciler_validate(t *testing.T) {
 				SemanticEquals:             func(a1, a2 *corev1.Pod) bool { return false },
 				OurChild:                   func(parent *corev1.Secret, child *corev1.Pod) bool { return false },
 			},
-			shouldErr: "ChildReconciler must implement OurChild: nil | func(*v1.ConfigMap, *v1.Pod) bool, found: func(*v1.Secret, *v1.Pod) bool",
+			shouldErr: `ChildReconciler "OurChild in 2" must implement OurChild: nil | func(*v1.ConfigMap, *v1.Pod) bool, found: func(*v1.Secret, *v1.Pod) bool`,
 		},
 		{
 			name:   "OurChild num out",
 			parent: &corev1.ConfigMap{},
 			reconciler: &ChildReconciler{
+				Name:                       "OurChild num out",
 				ChildType:                  &corev1.Pod{},
 				ChildListType:              &corev1.PodList{},
 				DesiredChild:               func(ctx context.Context, parent *corev1.ConfigMap) (*corev1.Pod, error) { return nil, nil },
@@ -695,12 +737,13 @@ func TestChildReconciler_validate(t *testing.T) {
 				SemanticEquals:             func(a1, a2 *corev1.Pod) bool { return false },
 				OurChild:                   func(parent *corev1.ConfigMap, child *corev1.Pod) {},
 			},
-			shouldErr: "ChildReconciler must implement OurChild: nil | func(*v1.ConfigMap, *v1.Pod) bool, found: func(*v1.ConfigMap, *v1.Pod)",
+			shouldErr: `ChildReconciler "OurChild num out" must implement OurChild: nil | func(*v1.ConfigMap, *v1.Pod) bool, found: func(*v1.ConfigMap, *v1.Pod)`,
 		},
 		{
 			name:   "OurChild out 1",
 			parent: &corev1.ConfigMap{},
 			reconciler: &ChildReconciler{
+				Name:                       "OurChild out 1",
 				ChildType:                  &corev1.Pod{},
 				ChildListType:              &corev1.PodList{},
 				DesiredChild:               func(ctx context.Context, parent *corev1.ConfigMap) (*corev1.Pod, error) { return nil, nil },
@@ -709,7 +752,7 @@ func TestChildReconciler_validate(t *testing.T) {
 				SemanticEquals:             func(a1, a2 *corev1.Pod) bool { return false },
 				OurChild:                   func(parent *corev1.ConfigMap, child *corev1.Pod) *corev1.Pod { return child },
 			},
-			shouldErr: "ChildReconciler must implement OurChild: nil | func(*v1.ConfigMap, *v1.Pod) bool, found: func(*v1.ConfigMap, *v1.Pod) *v1.Pod",
+			shouldErr: `ChildReconciler "OurChild out 1" must implement OurChild: nil | func(*v1.ConfigMap, *v1.Pod) bool, found: func(*v1.ConfigMap, *v1.Pod) *v1.Pod`,
 		},
 		{
 			name:   "Sanitize",
@@ -728,6 +771,7 @@ func TestChildReconciler_validate(t *testing.T) {
 			name:   "Sanitize num in",
 			parent: &corev1.ConfigMap{},
 			reconciler: &ChildReconciler{
+				Name:                       "Sanitize num in",
 				ChildType:                  &corev1.Pod{},
 				ChildListType:              &corev1.PodList{},
 				DesiredChild:               func(ctx context.Context, parent *corev1.ConfigMap) (*corev1.Pod, error) { return nil, nil },
@@ -736,12 +780,13 @@ func TestChildReconciler_validate(t *testing.T) {
 				SemanticEquals:             func(a1, a2 *corev1.Pod) bool { return false },
 				Sanitize:                   func() corev1.PodSpec { return corev1.PodSpec{} },
 			},
-			shouldErr: "ChildReconciler must implement Sanitize: nil | func(*v1.Pod) interface{}, found: func() v1.PodSpec",
+			shouldErr: `ChildReconciler "Sanitize num in" must implement Sanitize: nil | func(*v1.Pod) interface{}, found: func() v1.PodSpec`,
 		},
 		{
 			name:   "Sanitize in 1",
 			parent: &corev1.ConfigMap{},
 			reconciler: &ChildReconciler{
+				Name:                       "Sanitize in 1",
 				ChildType:                  &corev1.Pod{},
 				ChildListType:              &corev1.PodList{},
 				DesiredChild:               func(ctx context.Context, parent *corev1.ConfigMap) (*corev1.Pod, error) { return nil, nil },
@@ -750,12 +795,13 @@ func TestChildReconciler_validate(t *testing.T) {
 				SemanticEquals:             func(a1, a2 *corev1.Pod) bool { return false },
 				Sanitize:                   func(child *corev1.Secret) corev1.PodSpec { return corev1.PodSpec{} },
 			},
-			shouldErr: "ChildReconciler must implement Sanitize: nil | func(*v1.Pod) interface{}, found: func(*v1.Secret) v1.PodSpec",
+			shouldErr: `ChildReconciler "Sanitize in 1" must implement Sanitize: nil | func(*v1.Pod) interface{}, found: func(*v1.Secret) v1.PodSpec`,
 		},
 		{
 			name:   "Sanitize num out",
 			parent: &corev1.ConfigMap{},
 			reconciler: &ChildReconciler{
+				Name:                       "Sanitize num out",
 				ChildType:                  &corev1.Pod{},
 				ChildListType:              &corev1.PodList{},
 				DesiredChild:               func(ctx context.Context, parent *corev1.ConfigMap) (*corev1.Pod, error) { return nil, nil },
@@ -764,7 +810,7 @@ func TestChildReconciler_validate(t *testing.T) {
 				SemanticEquals:             func(a1, a2 *corev1.Pod) bool { return false },
 				Sanitize:                   func(child *corev1.Pod) {},
 			},
-			shouldErr: "ChildReconciler must implement Sanitize: nil | func(*v1.Pod) interface{}, found: func(*v1.Pod)",
+			shouldErr: `ChildReconciler "Sanitize num out" must implement Sanitize: nil | func(*v1.Pod) interface{}, found: func(*v1.Pod)`,
 		},
 	}
 

--- a/reconcilers/reconcilers_validate_test.go
+++ b/reconcilers/reconcilers_validate_test.go
@@ -25,8 +25,8 @@ func TestSyncReconciler_validate(t *testing.T) {
 		{
 			name:       "empty",
 			parent:     &corev1.ConfigMap{},
-			reconciler: &SyncReconciler{Name: "empty"},
-			shouldErr:  `SyncReconciler "empty" must implement Sync`,
+			reconciler: &SyncReconciler{},
+			shouldErr:  `SyncReconciler "" must implement Sync`,
 		},
 		{
 			name:   "valid",
@@ -217,7 +217,7 @@ func TestChildReconciler_validate(t *testing.T) {
 			name:       "empty",
 			parent:     &corev1.ConfigMap{},
 			reconciler: &ChildReconciler{},
-			shouldErr:  "ChildType must be defined",
+			shouldErr:  `ChildReconciler "" must define ChildType`,
 		},
 		{
 			name:   "valid",
@@ -235,6 +235,7 @@ func TestChildReconciler_validate(t *testing.T) {
 			name:   "ChildType missing",
 			parent: &corev1.ConfigMap{},
 			reconciler: &ChildReconciler{
+				Name: "ChildType missing",
 				// ChildType:                  &corev1.Pod{},
 				ChildListType:              &corev1.PodList{},
 				DesiredChild:               func(ctx context.Context, parent *corev1.ConfigMap) (*corev1.Pod, error) { return nil, nil },
@@ -242,12 +243,13 @@ func TestChildReconciler_validate(t *testing.T) {
 				MergeBeforeUpdate:          func(current, desired *corev1.Pod) {},
 				SemanticEquals:             func(a1, a2 *corev1.Pod) bool { return false },
 			},
-			shouldErr: "ChildType must be defined",
+			shouldErr: `ChildReconciler "ChildType missing" must define ChildType`,
 		},
 		{
 			name:   "ChildListType missing",
 			parent: &corev1.ConfigMap{},
 			reconciler: &ChildReconciler{
+				Name:      "ChildListType missing",
 				ChildType: &corev1.Pod{},
 				// ChildListType:              &corev1.PodList{},
 				DesiredChild:               func(ctx context.Context, parent *corev1.ConfigMap) (*corev1.Pod, error) { return nil, nil },
@@ -255,7 +257,7 @@ func TestChildReconciler_validate(t *testing.T) {
 				MergeBeforeUpdate:          func(current, desired *corev1.Pod) {},
 				SemanticEquals:             func(a1, a2 *corev1.Pod) bool { return false },
 			},
-			shouldErr: "ChildListType must be defined",
+			shouldErr: `ChildReconciler "ChildListType missing" must define ChildListType`,
 		},
 		{
 			name:   "DesiredChild missing",
@@ -465,7 +467,7 @@ func TestChildReconciler_validate(t *testing.T) {
 				MergeBeforeUpdate:          func() {},
 				SemanticEquals:             func(a1, a2 *corev1.Pod) bool { return false },
 			},
-			shouldErr: `ChildReconciler "MergeBeforeUpdate num in" must implement MergeBeforeUpdate: nil | func(*v1.Pod, *v1.Pod), found: func()`,
+			shouldErr: `ChildReconciler "MergeBeforeUpdate num in" must implement MergeBeforeUpdate: func(*v1.Pod, *v1.Pod), found: func()`,
 		},
 		{
 			name:   "MergeBeforeUpdate in 0",
@@ -479,7 +481,7 @@ func TestChildReconciler_validate(t *testing.T) {
 				MergeBeforeUpdate:          func(current *corev1.Secret, desired *corev1.Pod) {},
 				SemanticEquals:             func(a1, a2 *corev1.Pod) bool { return false },
 			},
-			shouldErr: `ChildReconciler "MergeBeforeUpdate in 0" must implement MergeBeforeUpdate: nil | func(*v1.Pod, *v1.Pod), found: func(*v1.Secret, *v1.Pod)`,
+			shouldErr: `ChildReconciler "MergeBeforeUpdate in 0" must implement MergeBeforeUpdate: func(*v1.Pod, *v1.Pod), found: func(*v1.Secret, *v1.Pod)`,
 		},
 		{
 			name:   "MergeBeforeUpdate in 1",
@@ -493,7 +495,7 @@ func TestChildReconciler_validate(t *testing.T) {
 				MergeBeforeUpdate:          func(current *corev1.Pod, desired *corev1.Secret) {},
 				SemanticEquals:             func(a1, a2 *corev1.Pod) bool { return false },
 			},
-			shouldErr: `ChildReconciler "MergeBeforeUpdate in 1" must implement MergeBeforeUpdate: nil | func(*v1.Pod, *v1.Pod), found: func(*v1.Pod, *v1.Secret)`,
+			shouldErr: `ChildReconciler "MergeBeforeUpdate in 1" must implement MergeBeforeUpdate: func(*v1.Pod, *v1.Pod), found: func(*v1.Pod, *v1.Secret)`,
 		},
 		{
 			name:   "MergeBeforeUpdate num out",
@@ -507,7 +509,7 @@ func TestChildReconciler_validate(t *testing.T) {
 				MergeBeforeUpdate:          func(current, desired *corev1.Pod) error { return nil },
 				SemanticEquals:             func(a1, a2 *corev1.Pod) bool { return false },
 			},
-			shouldErr: `ChildReconciler "MergeBeforeUpdate num out" must implement MergeBeforeUpdate: nil | func(*v1.Pod, *v1.Pod), found: func(*v1.Pod, *v1.Pod) error`,
+			shouldErr: `ChildReconciler "MergeBeforeUpdate num out" must implement MergeBeforeUpdate: func(*v1.Pod, *v1.Pod), found: func(*v1.Pod, *v1.Pod) error`,
 		},
 		{
 			name:   "SemanticEquals missing",
@@ -535,7 +537,7 @@ func TestChildReconciler_validate(t *testing.T) {
 				MergeBeforeUpdate:          func(current, desired *corev1.Pod) {},
 				SemanticEquals:             func() bool { return false },
 			},
-			shouldErr: `ChildReconciler "SemanticEquals num in" must implement SemanticEquals: nil | func(*v1.Pod, *v1.Pod) bool, found: func() bool`,
+			shouldErr: `ChildReconciler "SemanticEquals num in" must implement SemanticEquals: func(*v1.Pod, *v1.Pod) bool, found: func() bool`,
 		},
 		{
 			name:   "SemanticEquals in 0",
@@ -549,7 +551,7 @@ func TestChildReconciler_validate(t *testing.T) {
 				MergeBeforeUpdate:          func(current, desired *corev1.Pod) {},
 				SemanticEquals:             func(a1 *corev1.Secret, a2 *corev1.Pod) bool { return false },
 			},
-			shouldErr: `ChildReconciler "SemanticEquals in 0" must implement SemanticEquals: nil | func(*v1.Pod, *v1.Pod) bool, found: func(*v1.Secret, *v1.Pod) bool`,
+			shouldErr: `ChildReconciler "SemanticEquals in 0" must implement SemanticEquals: func(*v1.Pod, *v1.Pod) bool, found: func(*v1.Secret, *v1.Pod) bool`,
 		},
 		{
 			name:   "SemanticEquals in 1",
@@ -563,7 +565,7 @@ func TestChildReconciler_validate(t *testing.T) {
 				MergeBeforeUpdate:          func(current, desired *corev1.Pod) {},
 				SemanticEquals:             func(a1 *corev1.Pod, a2 *corev1.Secret) bool { return false },
 			},
-			shouldErr: `ChildReconciler "SemanticEquals in 1" must implement SemanticEquals: nil | func(*v1.Pod, *v1.Pod) bool, found: func(*v1.Pod, *v1.Secret) bool`,
+			shouldErr: `ChildReconciler "SemanticEquals in 1" must implement SemanticEquals: func(*v1.Pod, *v1.Pod) bool, found: func(*v1.Pod, *v1.Secret) bool`,
 		},
 		{
 			name:   "SemanticEquals num out",
@@ -577,7 +579,7 @@ func TestChildReconciler_validate(t *testing.T) {
 				MergeBeforeUpdate:          func(current, desired *corev1.Pod) {},
 				SemanticEquals:             func(a1, a2 *corev1.Pod) {},
 			},
-			shouldErr: `ChildReconciler "SemanticEquals num out" must implement SemanticEquals: nil | func(*v1.Pod, *v1.Pod) bool, found: func(*v1.Pod, *v1.Pod)`,
+			shouldErr: `ChildReconciler "SemanticEquals num out" must implement SemanticEquals: func(*v1.Pod, *v1.Pod) bool, found: func(*v1.Pod, *v1.Pod)`,
 		},
 		{
 			name:   "SemanticEquals out 0",
@@ -591,7 +593,7 @@ func TestChildReconciler_validate(t *testing.T) {
 				MergeBeforeUpdate:          func(current, desired *corev1.Pod) {},
 				SemanticEquals:             func(a1, a2 *corev1.Pod) error { return nil },
 			},
-			shouldErr: `ChildReconciler "SemanticEquals out 0" must implement SemanticEquals: nil | func(*v1.Pod, *v1.Pod) bool, found: func(*v1.Pod, *v1.Pod) error`,
+			shouldErr: `ChildReconciler "SemanticEquals out 0" must implement SemanticEquals: func(*v1.Pod, *v1.Pod) bool, found: func(*v1.Pod, *v1.Pod) error`,
 		},
 		{
 			name:   "HarmonizeImmutableFields",
@@ -836,7 +838,7 @@ func TestCastParent_validate(t *testing.T) {
 			name:       "empty",
 			parent:     &corev1.ConfigMap{},
 			reconciler: &CastParent{},
-			shouldErr:  "Type must be defined",
+			shouldErr:  `CastParent "" must define Type`,
 		},
 		{
 			name:   "valid",
@@ -854,6 +856,7 @@ func TestCastParent_validate(t *testing.T) {
 			name:   "missing type",
 			parent: &corev1.ConfigMap{},
 			reconciler: &CastParent{
+				Name: "missing type",
 				Type: nil,
 				Reconciler: &SyncReconciler{
 					Sync: func(ctx context.Context, parent *corev1.Secret) error {
@@ -861,16 +864,17 @@ func TestCastParent_validate(t *testing.T) {
 					},
 				},
 			},
-			shouldErr: "Type must be defined",
+			shouldErr: `CastParent "missing type" must define Type`,
 		},
 		{
 			name:   "missing reconciler",
 			parent: &corev1.ConfigMap{},
 			reconciler: &CastParent{
+				Name:       "missing reconciler",
 				Type:       &corev1.Secret{},
 				Reconciler: nil,
 			},
-			shouldErr: "Reconciler must be defined",
+			shouldErr: `CastParent "missing reconciler" must define Reconciler`,
 		},
 	}
 
@@ -900,7 +904,7 @@ func TestWithConfig_validate(t *testing.T) {
 			name:       "empty",
 			parent:     &corev1.ConfigMap{},
 			reconciler: &WithConfig{},
-			shouldErr:  "Config must be defined",
+			shouldErr:  `WithConfig "" must define Config`,
 		},
 		{
 			name:   "valid",
@@ -916,19 +920,21 @@ func TestWithConfig_validate(t *testing.T) {
 			name:   "missing config",
 			parent: &corev1.ConfigMap{},
 			reconciler: &WithConfig{
+				Name:       "missing config",
 				Reconciler: &Sequence{},
 			},
-			shouldErr: "Config must be defined",
+			shouldErr: `WithConfig "missing config" must define Config`,
 		},
 		{
 			name:   "missing reconciler",
 			parent: &corev1.ConfigMap{},
 			reconciler: &WithConfig{
+				Name: "missing reconciler",
 				Config: func(ctx context.Context, c Config) (Config, error) {
 					return config, nil
 				},
 			},
-			shouldErr: "Reconciler must be defined",
+			shouldErr: `WithConfig "missing reconciler" must define Reconciler`,
 		},
 	}
 
@@ -954,7 +960,7 @@ func TestWithFinalizer_validate(t *testing.T) {
 			name:       "empty",
 			parent:     &corev1.ConfigMap{},
 			reconciler: &WithFinalizer{},
-			shouldErr:  "Finalizer must be defined",
+			shouldErr:  `WithFinalizer "" must define Finalizer`,
 		},
 		{
 			name:   "valid",
@@ -968,17 +974,19 @@ func TestWithFinalizer_validate(t *testing.T) {
 			name:   "missing finalizer",
 			parent: &corev1.ConfigMap{},
 			reconciler: &WithFinalizer{
+				Name:       "missing finalizer",
 				Reconciler: &Sequence{},
 			},
-			shouldErr: "Finalizer must be defined",
+			shouldErr: `WithFinalizer "missing finalizer" must define Finalizer`,
 		},
 		{
 			name:   "missing reconciler",
 			parent: &corev1.ConfigMap{},
 			reconciler: &WithFinalizer{
+				Name:      "missing reconciler",
 				Finalizer: "my-finalizer",
 			},
-			shouldErr: "Reconciler must be defined",
+			shouldErr: `WithFinalizer "missing reconciler" must define Reconciler`,
 		},
 	}
 


### PR DESCRIPTION
Makes it easier to find invalid reconcilers by including the offending reconciler's name in the error message.