### PR TITLE
TrackAndGet

### DIFF
--- a/testing/subreconciler.go
+++ b/testing/subreconciler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/vmware-labs/reconciler-runtime/reconcilers"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -170,6 +171,9 @@ func (tc *SubReconcilerTestCase) Run(t *testing.T, scheme *runtime.Scheme, facto
 		// this value is also set by the test client when resource are added as givens
 		parent.SetResourceVersion("999")
 	}
+	ctx = reconcilers.StashRequest(ctx, reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: parent.GetNamespace(), Name: parent.GetName()},
+	})
 	ctx = reconcilers.StashParentType(ctx, parent.DeepCopyObject().(client.Object))
 	ctx = reconcilers.StashCastParentType(ctx, parent.DeepCopyObject().(client.Object))
 


### PR DESCRIPTION
Streamline the flow for looking up a resource and watching it for
changes. The Tracker has long lived on the Config object as a peer to
the Client, it's very common to Track() a resource and then Get() that
same resource. Now we can do both, this effectively makes tracking
transparent as TrackAndGet() and Get() have the same method signature.

Before:

    c.Tracker.Track(
        ctx,
        tracker.NewKey(
           schema.GroupVersionKind{Version: "v1", Kind: "ServiceAccount"},
           types.NamespacedName{Namespace: parent.Namespace, Name: serviceAccountName},
        ),
        types.NamespacedName{Namespace: parent.Namespace, Name: parent.Name},
    )
    serviceAccount := corev1.ServiceAccount{}
    err := c.Get(ctx, types.NamespacedName{Namespace: parent.Namespace, Name: serviceAccountName}, &serviceAccount)

After:

    serviceAccount := corev1.ServiceAccount{}
    err := c.TrackAndGet(ctx, types.NamespacedName{Namespace: parent.Namespace, Name: serviceAccountName}, &serviceAccount)

The implementation assumes the ctx extends from a ParentReconciler.

Resolves #164 