### PR TITLE
Use ExpectConfig to manage config expectations and assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 - [Testing](#testing)
 	- [ReconcilerTests](#reconcilertests)
 	- [SubReconcilerTests](#subreconcilertests)
+	- [ExpectConfig](#expectconfig)
 - [Utilities](#utilities)
 	- [Config](#config)
 	- [Stash](#stash)
@@ -588,11 +589,15 @@ rts.Test(t, scheme, func(t *testing.T, rtc *rtesting.SubReconcilerTestCase, c re
 ```
 [full source](https://github.com/projectriff/system/blob/4c3b75327bf99cc37b57ba14df4c65d21dc79d28/pkg/controllers/streaming/processor_reconciler_test.go#L279-L305)
 
+### ExpectConfig
+
+The [`ExpectConfig`](https://pkg.go.dev/github.com/vmware-labs/reconciler-runtime/testing#ExpectConfig) is a testing object that can create a [Config](#config) with given test state that will observe the reconciler's behavior against the config and can assert that the observed behavior matches the expected behavior. When used with the `AdditionalConfigs` field of [ReconcilerTestCase](#reconcilertests) and [SubReconcilerTestCase](#subreconcilertests), the corresponding configs can be obtained with [`RetrieveAdditionalConfigs`](https://pkg.go.dev/github.com/vmware-labs/reconciler-runtime/reconcilers#RetrieveAdditionalConfigs). Use of `RetrieveAdditionalConfigs` should be limited to a reconciler that is dedicated to work with multiple configs like [WithConfig](#withconfig); reconcilers nested under WithConfig should interact with the default config.
+
 ## Utilities
 
 ### Config
 
-The [`Config`](https://pkg.go.dev/github.com/vmware-labs/reconciler-runtime/reconcilers#Config) is a single object that contains the key APIs needed by a reconciler. The config object is provided to the reconciler when initialized and is preconfigured for the reconciler.
+The [`Config`](https://pkg.go.dev/github.com/vmware-labs/reconciler-runtime/reconcilers#Config) is a single object that contains the key APIs needed by a reconciler. The config object is provided to the reconciler when initialized and is preconfigured for the reconciler. To setup a Config for a test and make assertions that the expected behavior matches the observed behavior, use [ExpectConfig](#expectconfig)
 
 ### Stash
 

--- a/reconcilers/reconcilers.go
+++ b/reconcilers/reconcilers.go
@@ -645,6 +645,7 @@ const configStashKey StashKey = "reconciler-runtime:config"
 const originalConfigStashKey StashKey = "reconciler-runtime:originalConfig"
 const resourceTypeStashKey StashKey = "reconciler-runtime:resourceType"
 const originalResourceTypeStashKey StashKey = "reconciler-runtime:originalResourceType"
+const additionalConfigsStashKey StashKey = "reconciler-runtime:additionalConfigs"
 
 func StashRequest(ctx context.Context, req ctrl.Request) context.Context {
 	return context.WithValue(ctx, requestStashKey, req)
@@ -750,6 +751,20 @@ func RetrieveOriginalResourceType(ctx context.Context) client.Object {
 		return resourceType
 	}
 	return nil
+}
+
+func StashAdditionalConfigs(ctx context.Context, additionalConfigs map[string]Config) context.Context {
+	return context.WithValue(ctx, additionalConfigsStashKey, additionalConfigs)
+}
+
+// RetrieveAdditionalConfigs returns the additional configs defined for this request. Uncommon
+// outside of the context of a test. An empty map is returned when no value is stashed.
+func RetrieveAdditionalConfigs(ctx context.Context) map[string]Config {
+	value := ctx.Value(additionalConfigsStashKey)
+	if additionalConfigs, ok := value.(map[string]Config); ok {
+		return additionalConfigs
+	}
+	return map[string]Config{}
 }
 
 // SubReconciler are participants in a larger reconciler request. The resource

--- a/testing/config.go
+++ b/testing/config.go
@@ -1,0 +1,402 @@
+/*
+Copyright 2022 VMware, Inc.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package testing
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/vmware-labs/reconciler-runtime/reconcilers"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ExpectConfig encompasses the creation of a config object using given state, captures observed
+// behavior of the reconciler and asserts expected behavior against the observed behavior.
+//
+// This object is driven implicitly by ReconcilerTestCase and SubReconcilerTestCase. A reconciler
+// that needs to interact with multiple configs can create and manage additional ExpectConfigs with
+// their own expectations. For example, when a WithConfig reconciler is used the SubReconcilers
+// under it use a config separate from the config originally used to load the reconciled resource.
+type ExpectConfig struct {
+	// Name is used when reporting assertion failures to distinguish configs
+	Name string
+
+	// Scheme allows the client to map Go structs to Kubernetes GVKs. All structured resources
+	// that are expected to interact with this config should be registered within the scheme.
+	Scheme *runtime.Scheme
+	// GivenObjects build the kubernetes objects which are present at the onset of reconciliation
+	GivenObjects []client.Object
+	// APIGivenObjects contains objects that are only available via an API reader instead of the normal cache
+	APIGivenObjects []client.Object
+	// WithReactors installs each ReactionFunc into each fake clientset. ReactionFuncs intercept
+	// each call to the clientset providing the ability to mutate the resource or inject an error.
+	WithReactors []ReactionFunc
+
+	// side effects
+
+	// ExpectTracks holds the ordered list of Track calls expected during reconciliation
+	ExpectTracks []TrackRequest
+	// ExpectEvents holds the ordered list of events recorded during the reconciliation
+	ExpectEvents []Event
+	// ExpectCreates builds the ordered list of objects expected to be created during reconciliation
+	ExpectCreates []client.Object
+	// ExpectUpdates builds the ordered list of objects expected to be updated during reconciliation
+	ExpectUpdates []client.Object
+	// ExpectPatches builds the ordered list of objects expected to be patched during reconciliation
+	ExpectPatches []PatchRef
+	// ExpectDeletes holds the ordered list of objects expected to be deleted during reconciliation
+	ExpectDeletes []DeleteRef
+	// ExpectDeleteCollections holds the ordered list of collections expected to be deleted during reconciliation
+	ExpectDeleteCollections []DeleteCollectionRef
+	// ExpectStatusUpdates builds the ordered list of objects whose status is updated during reconciliation
+	ExpectStatusUpdates []client.Object
+	// ExpectStatusPatches builds the ordered list of objects whose status is patched during reconciliation
+	ExpectStatusPatches []PatchRef
+
+	once      sync.Once
+	client    *clientWrapper
+	apiReader *clientWrapper
+	recorder  *eventRecorder
+	tracker   *mockTracker
+}
+
+func (c *ExpectConfig) init() {
+	c.once.Do(func() {
+		c.client = NewFakeClient(c.Scheme, c.GivenObjects...)
+		for i := range c.WithReactors {
+			// in reverse order since we prepend
+			reactor := c.WithReactors[len(c.WithReactors)-1-i]
+			c.client.PrependReactor("*", "*", reactor)
+		}
+		c.apiReader = NewFakeClient(c.Scheme, c.APIGivenObjects...)
+		c.recorder = &eventRecorder{
+			events: []Event{},
+			scheme: c.Scheme,
+		}
+		c.tracker = createTracker()
+	})
+}
+
+// Config returns the Config object. This method should only be called once. Subsequent calls are
+// ignored returning the Config from the first call.
+func (c *ExpectConfig) Config() reconcilers.Config {
+	c.init()
+	return reconcilers.Config{
+		Client:    c.client,
+		APIReader: c.apiReader,
+		Recorder:  c.recorder,
+		Tracker:   c.tracker,
+		// Log is deprecated and should not be used. Setting the discard logger until it is fully removed.
+		Log: logr.Discard(),
+	}
+}
+
+// AssertExpectations asserts all observed reconciler behavior matches the expected behavior
+func (c *ExpectConfig) AssertExpectations(t *testing.T) {
+	t.Helper()
+	c.init()
+
+	c.AssertClientExpectations(t)
+	c.AssertRecorderExpectations(t)
+	c.AssertTrackerExpectations(t)
+}
+
+// AssertClientExpectations asserts observed reconciler client behavior matches the expected client behavior
+func (c *ExpectConfig) AssertClientExpectations(t *testing.T) {
+	t.Helper()
+	c.init()
+
+	c.AssertClientCreateExpectations(t)
+	c.AssertClientUpdateExpectations(t)
+	c.AssertClientPatchExpectations(t)
+	c.AssertClientDeleteExpectations(t)
+	c.AssertClientDeleteCollectionExpectations(t)
+	c.AssertClientStatusUpdateExpectations(t)
+	c.AssertClientStatusPatchExpectations(t)
+}
+
+// AssertClientCreateExpectations asserts observed reconciler client create behavior matches the expected client create behavior
+func (c *ExpectConfig) AssertClientCreateExpectations(t *testing.T) {
+	t.Helper()
+	c.init()
+
+	c.compareActions(t, "create", c.ExpectCreates, c.client.CreateActions, IgnoreLastTransitionTime, SafeDeployDiff, IgnoreTypeMeta, IgnoreResourceVersion, cmpopts.EquateEmpty())
+}
+
+// AssertClientUpdateExpectations asserts observed reconciler client update behavior matches the expected client update behavior
+func (c *ExpectConfig) AssertClientUpdateExpectations(t *testing.T) {
+	t.Helper()
+	c.init()
+
+	c.compareActions(t, "update", c.ExpectUpdates, c.client.UpdateActions, IgnoreLastTransitionTime, SafeDeployDiff, IgnoreTypeMeta, IgnoreResourceVersion, cmpopts.EquateEmpty())
+}
+
+// AssertClientPatchExpectations asserts observed reconciler client patch behavior matches the expected client patch behavior
+func (c *ExpectConfig) AssertClientPatchExpectations(t *testing.T) {
+	t.Helper()
+	c.init()
+
+	for i, exp := range c.ExpectPatches {
+		if i >= len(c.client.PatchActions) {
+			t.Errorf("Missing patch for config %q: %#v", c.Name, exp)
+			continue
+		}
+		actual := NewPatchRef(c.client.PatchActions[i])
+
+		if diff := cmp.Diff(exp, actual); diff != "" {
+			t.Errorf("Unexpected patch for config %q (-expected, +actual): %s", c.Name, diff)
+		}
+	}
+	if actual, expected := len(c.client.PatchActions), len(c.ExpectPatches); actual > expected {
+		for _, extra := range c.client.PatchActions[expected:] {
+			t.Errorf("Extra patch for config %q: %#v", c.Name, extra)
+		}
+	}
+}
+
+// AssertClientDeleteExpectations asserts observed reconciler client delete behavior matches the expected client delete behavior
+func (c *ExpectConfig) AssertClientDeleteExpectations(t *testing.T) {
+	t.Helper()
+	c.init()
+
+	for i, exp := range c.ExpectDeletes {
+		if i >= len(c.client.DeleteActions) {
+			t.Errorf("Missing delete for config %q: %#v", c.Name, exp)
+			continue
+		}
+		actual := NewDeleteRef(c.client.DeleteActions[i])
+
+		if diff := cmp.Diff(exp, actual); diff != "" {
+			t.Errorf("Unexpected delete for config %q (-expected, +actual): %s", c.Name, diff)
+		}
+	}
+	if actual, expected := len(c.client.DeleteActions), len(c.ExpectDeletes); actual > expected {
+		for _, extra := range c.client.DeleteActions[expected:] {
+			t.Errorf("Extra delete for config %q: %#v", c.Name, extra)
+		}
+	}
+}
+
+// AssertClientDeleteCollectionExpectations asserts observed reconciler client delete collection behavior matches the expected client delete collection behavior
+func (c *ExpectConfig) AssertClientDeleteCollectionExpectations(t *testing.T) {
+	t.Helper()
+	c.init()
+
+	for i, exp := range c.ExpectDeleteCollections {
+		if i >= len(c.client.DeleteCollectionActions) {
+			t.Errorf("Missing delete collection for config %q: %#v", c.Name, exp)
+			continue
+		}
+		actual := NewDeleteCollectionRef(c.client.DeleteCollectionActions[i])
+
+		if diff := cmp.Diff(exp, actual); diff != "" {
+			t.Errorf("Unexpected delete collection for config %q (-expected, +actual): %s", c.Name, diff)
+		}
+	}
+	if actual, expected := len(c.client.DeleteCollectionActions), len(c.ExpectDeleteCollections); actual > expected {
+		for _, extra := range c.client.DeleteCollectionActions[expected:] {
+			t.Errorf("Extra delete collection for config %q: %#v", c.Name, extra)
+		}
+	}
+}
+
+// AssertClientStatusUpdateExpectations asserts observed reconciler client status update behavior matches the expected client status update behavior
+func (c *ExpectConfig) AssertClientStatusUpdateExpectations(t *testing.T) {
+	t.Helper()
+	c.init()
+
+	c.compareActions(t, "status update", c.ExpectStatusUpdates, c.client.StatusUpdateActions, statusSubresourceOnly, IgnoreLastTransitionTime, SafeDeployDiff, cmpopts.EquateEmpty())
+}
+
+// AssertClientStatusPatchExpectations asserts observed reconciler client status patch behavior matches the expected client status patch behavior
+func (c *ExpectConfig) AssertClientStatusPatchExpectations(t *testing.T) {
+	t.Helper()
+	c.init()
+
+	for i, exp := range c.ExpectStatusPatches {
+		if i >= len(c.client.StatusPatchActions) {
+			t.Errorf("Missing status patch for config %q: %#v", c.Name, exp)
+			continue
+		}
+		actual := NewPatchRef(c.client.StatusPatchActions[i])
+
+		if diff := cmp.Diff(exp, actual); diff != "" {
+			t.Errorf("Unexpected status patch for config %q (-expected, +actual): %s", c.Name, diff)
+		}
+	}
+	if actual, expected := len(c.client.StatusPatchActions), len(c.ExpectStatusPatches); actual > expected {
+		for _, extra := range c.client.StatusPatchActions[expected:] {
+			t.Errorf("Extra status patch for config %q: %#v", c.Name, extra)
+		}
+	}
+}
+
+// AssertRecorderExpectations asserts observed event recorder behavior matches the expected event recorder behavior
+func (c *ExpectConfig) AssertRecorderExpectations(t *testing.T) {
+	t.Helper()
+	c.init()
+
+	actualEvents := c.recorder.events
+	for i, exp := range c.ExpectEvents {
+		if i >= len(actualEvents) {
+			t.Errorf("Missing recorded event for config %q: %s", c.Name, exp)
+			continue
+		}
+
+		if diff := cmp.Diff(exp, actualEvents[i]); diff != "" {
+			t.Errorf("Unexpected recorded event for config %q (-expected, +actual): %s", c.Name, diff)
+		}
+	}
+	if actual, exp := len(actualEvents), len(c.ExpectEvents); actual > exp {
+		for _, extra := range actualEvents[exp:] {
+			t.Errorf("Extra recorded event for config %q: %s", c.Name, extra)
+		}
+	}
+}
+
+// AssertTrackerExpectations asserts observed tracker behavior matches the expected tracker behavior
+func (c *ExpectConfig) AssertTrackerExpectations(t *testing.T) {
+	t.Helper()
+	c.init()
+
+	actualTracks := c.tracker.getTrackRequests()
+	for i, exp := range c.ExpectTracks {
+		if i >= len(actualTracks) {
+			t.Errorf("Missing tracking request for config %q: %s", c.Name, exp)
+			continue
+		}
+
+		if diff := cmp.Diff(exp, actualTracks[i]); diff != "" {
+			t.Errorf("Unexpected tracking request for config %q (-expected, +actual): %s", c.Name, diff)
+		}
+	}
+	if actual, exp := len(actualTracks), len(c.ExpectTracks); actual > exp {
+		for _, extra := range actualTracks[exp:] {
+			t.Errorf("Extra tracking request for config %q: %s", c.Name, extra)
+		}
+	}
+}
+
+func (c *ExpectConfig) compareActions(t *testing.T, actionName string, expectedActionFactories []client.Object, actualActions []objectAction, diffOptions ...cmp.Option) {
+	// TODO(scothis) this could be a really good place to play with generics
+	t.Helper()
+	c.init()
+
+	for i, exp := range expectedActionFactories {
+		if i >= len(actualActions) {
+			t.Errorf("Missing %s: %#v", actionName, exp.DeepCopyObject())
+			continue
+		}
+		actual := actualActions[i].GetObject()
+
+		if diff := cmp.Diff(exp.DeepCopyObject(), actual, diffOptions...); diff != "" {
+			t.Errorf("Unexpected %s for config %q (-expected, +actual): %s", actionName, c.Name, diff)
+		}
+	}
+	if actual, expected := len(actualActions), len(expectedActionFactories); actual > expected {
+		for _, extra := range actualActions[expected:] {
+			t.Errorf("Extra %s for config %q: %#v", actionName, c.Name, extra)
+		}
+	}
+}
+
+var (
+	IgnoreLastTransitionTime = cmp.FilterPath(func(p cmp.Path) bool {
+		return strings.HasSuffix(p.String(), "LastTransitionTime")
+	}, cmp.Ignore())
+	IgnoreTypeMeta = cmp.FilterPath(func(p cmp.Path) bool {
+		path := p.String()
+		return strings.HasSuffix(path, "TypeMeta.APIVersion") || strings.HasSuffix(path, "TypeMeta.Kind")
+	}, cmp.Ignore())
+	IgnoreResourceVersion = cmp.FilterPath(func(p cmp.Path) bool {
+		path := p.String()
+		return strings.HasSuffix(path, "ObjectMeta.ResourceVersion")
+	}, cmp.Ignore())
+
+	statusSubresourceOnly = cmp.FilterPath(func(p cmp.Path) bool {
+		q := p.String()
+		return q != "" && !strings.HasPrefix(q, "Status")
+	}, cmp.Ignore())
+
+	SafeDeployDiff = cmpopts.IgnoreUnexported(resource.Quantity{})
+)
+
+type PatchRef struct {
+	Group     string
+	Kind      string
+	Namespace string
+	Name      string
+	PatchType types.PatchType
+	Patch     []byte
+}
+
+func NewPatchRef(action PatchAction) PatchRef {
+	return PatchRef{
+		Group:     action.GetResource().Group,
+		Kind:      action.GetResource().Resource,
+		Namespace: action.GetNamespace(),
+		Name:      action.GetName(),
+		PatchType: action.GetPatchType(),
+		Patch:     action.GetPatch(),
+	}
+}
+
+type DeleteRef struct {
+	Group     string
+	Kind      string
+	Namespace string
+	Name      string
+}
+
+func NewDeleteRef(action DeleteAction) DeleteRef {
+	return DeleteRef{
+		Group:     action.GetResource().Group,
+		Kind:      action.GetResource().Resource,
+		Namespace: action.GetNamespace(),
+		Name:      action.GetName(),
+	}
+}
+
+func NewDeleteRefFromObject(obj client.Object, scheme *runtime.Scheme) DeleteRef {
+	gvks, _, err := scheme.ObjectKinds(obj.DeepCopyObject())
+	if err != nil {
+		panic(err)
+	}
+
+	return DeleteRef{
+		Group:     gvks[0].Group,
+		Kind:      gvks[0].Kind,
+		Namespace: obj.GetNamespace(),
+		Name:      obj.GetName(),
+	}
+}
+
+type DeleteCollectionRef struct {
+	Group     string
+	Kind      string
+	Namespace string
+	Labels    labels.Selector
+	Fields    fields.Selector
+}
+
+func NewDeleteCollectionRef(action DeleteCollectionAction) DeleteCollectionRef {
+	return DeleteCollectionRef{
+		Group:     action.GetResource().Group,
+		Kind:      action.GetResource().Resource,
+		Namespace: action.GetNamespace(),
+		Labels:    action.GetListRestrictions().Labels,
+		Fields:    action.GetListRestrictions().Fields,
+	}
+}

--- a/testing/subreconciler.go
+++ b/testing/subreconciler.go
@@ -134,24 +134,11 @@ func (tc *SubReconcilerTestCase) Run(t *testing.T, scheme *runtime.Scheme, facto
 		tc.ExpectResource = tc.ExpectParent
 	}
 
-	// Record the given objects
-	givenObjects := make([]client.Object, 0, len(tc.GivenObjects))
-	originalGivenObjects := make([]client.Object, 0, len(tc.GivenObjects))
-	for _, f := range tc.GivenObjects {
-		object := f.DeepCopyObject()
-		givenObjects = append(givenObjects, object.DeepCopyObject().(client.Object))
-		originalGivenObjects = append(originalGivenObjects, object.DeepCopyObject().(client.Object))
-	}
-	apiGivenObjects := make([]client.Object, 0, len(tc.APIGivenObjects))
-	for _, f := range tc.APIGivenObjects {
-		apiGivenObjects = append(apiGivenObjects, f.DeepCopyObject().(client.Object))
-	}
-
 	expectConfig := &ExpectConfig{
 		Name:                    "default",
 		Scheme:                  scheme,
-		GivenObjects:            append(givenObjects, tc.Resource.DeepCopyObject().(client.Object)),
-		APIGivenObjects:         append(apiGivenObjects, tc.Resource.DeepCopyObject().(client.Object)),
+		GivenObjects:            append(tc.GivenObjects, tc.Resource),
+		APIGivenObjects:         append(tc.APIGivenObjects, tc.Resource),
 		WithReactors:            tc.WithReactors,
 		ExpectTracks:            tc.ExpectTracks,
 		ExpectEvents:            tc.ExpectEvents,
@@ -261,11 +248,6 @@ func (tc *SubReconcilerTestCase) Run(t *testing.T, scheme *runtime.Scheme, facto
 	expectConfig.AssertExpectations(t)
 	for _, config := range tc.AdditionalConfigs {
 		config.AssertExpectations(t)
-	}
-
-	// Validate the given objects are not mutated by reconciliation
-	if diff := cmp.Diff(originalGivenObjects, givenObjects, SafeDeployDiff, IgnoreResourceVersion, cmpopts.EquateEmpty()); diff != "" {
-		t.Errorf("Given objects mutated by test %q (-expected, +actual): %v", tc.Name, diff)
 	}
 }
 


### PR DESCRIPTION
ExpectConfig is a testing object that can create a Config with given
test state that will observe the reconciler's behavior against the
config and can assert that the observed behavior matches the expected
behavior. While most commonly used internally within ReconcilerTestSuite
and SubReconcilerTestSuite, users of the WithConfig sub reconciler may
want to separate the expectations of different clients within the
reconciler.

Signed-off-by: Scott Andrews <andrewssc@vmware.com>