### PR TITLE
Restructure ReconcilerTestSuite to a map

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,7 +488,7 @@ There are two test suites, one for reconcilers and an optimized harness for test
 
 ### ReconcilerTests
 
-[`ReconcilerTestCase`](https://pkg.go.dev/github.com/vmware-labs/reconciler-runtime/testing#ReconcilerTestCase) run the full reconciler via the controller runtime Reconciler's Reconcile method. There are two ways to compose a ReconcilerTestCase either as an unordered set (using [`ReconcilerTests`](https://pkg.go.dev/github.com/vmware-labs/reconciler-runtime/testing#ReconcilerTests)) or an order list (using [`ReconcilerTestSuite`](https://pkg.go.dev/github.com/vmware-labs/reconciler-runtime/testing#ReconcilerTestSuite)). When using `ReconcilerTests` the key for each test case is used as the name for that test case.
+[`ReconcilerTestCase`](https://pkg.go.dev/github.com/vmware-labs/reconciler-runtime/testing#ReconcilerTestCase) run the full reconciler via the controller runtime Reconciler's Reconcile method. There are two ways to compose a ReconcilerTestCase either as an unordered set using [`ReconcilerTests`](https://pkg.go.dev/github.com/vmware-labs/reconciler-runtime/testing#ReconcilerTests), or an order list using [`ReconcilerTestSuite`](https://pkg.go.dev/github.com/vmware-labs/reconciler-runtime/testing#ReconcilerTestSuite). When using `ReconcilerTests` the key for each test case is used as the name for that test case.
 
 ```go
 testKey := ... // NamesapcedName of the resource to reconcile
@@ -550,7 +550,7 @@ For more complex reconcilers, the number of moving parts can make it difficult t
 - `GivenStashedValues` is a map of stashed value to seed, `ExpectStashedValues` are individually compared with the actual stashed value after the reconciler runs.
 - `ExpectStatusUpdates` is not available
 
-There are two ways to compose a SubReconcilerTestCase either as an unordered set (using [`SubReconcilerTests`](https://pkg.go.dev/github.com/vmware-labs/reconciler-runtime/testing#SubReconcilerTests)) or an order list (using [`SubReconcilerTestSuite`](https://pkg.go.dev/github.com/vmware-labs/reconciler-runtime/testing#SubReconcilerTestSuite)). When using `SubReconcilerTests` the key for each test case is used as the name for that test case.
+There are two ways to compose a SubReconcilerTestCase either as an unordered set using [`SubReconcilerTests`](https://pkg.go.dev/github.com/vmware-labs/reconciler-runtime/testing#SubReconcilerTests), or an order list using [`SubReconcilerTestSuite`](https://pkg.go.dev/github.com/vmware-labs/reconciler-runtime/testing#SubReconcilerTestSuite). When using `SubReconcilerTests` the key for each test case is used as the name for that test case.
 
 **Example:**
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@
 		- [WithConfig](#withconfig)
 		- [WithFinalizer](#withfinalizer)
 - [Testing](#testing)
-	- [ReconcilerTestSuite](#reconcilertestsuite)
-	- [SubReconcilerTestSuite](#subreconcilertestsuite)
+	- [ReconcilerTests](#reconcilertests)
+	- [SubReconcilerTests](#subreconcilertests)
 - [Utilities](#utilities)
 	- [Config](#config)
 	- [Stash](#stash)
@@ -484,9 +484,11 @@ The tests make extensive use of given and mutated resources. It is recommended t
 
 There are two test suites, one for reconcilers and an optimized harness for testing sub reconcilers.
 
-### ReconcilerTestSuite
+<a name="reconcilertestsuite" />
 
-[`ReconcilerTestCase`](https://pkg.go.dev/github.com/vmware-labs/reconciler-runtime/testing#ReconcilerTestCase) run the full reconciler via the controller runtime Reconciler's Reconcile method.
+### ReconcilerTests
+
+[`ReconcilerTestCase`](https://pkg.go.dev/github.com/vmware-labs/reconciler-runtime/testing#ReconcilerTestCase) run the full reconciler via the controller runtime Reconciler's Reconcile method. There are two ways to compose a ReconcilerTestCase either as an unordered set (using [`ReconcilerTests`](https://pkg.go.dev/github.com/vmware-labs/reconciler-runtime/testing#ReconcilerTests)) or an order list (using [`ReconcilerTestSuite`](https://pkg.go.dev/github.com/vmware-labs/reconciler-runtime/testing#ReconcilerTestSuite)). When using `ReconcilerTests` the key for each test case is used as the name for that test case.
 
 ```go
 testKey := ... // NamesapcedName of the resource to reconcile
@@ -495,42 +497,40 @@ inMemoryGateway := ... // resource to reconcile
 gatewayCreate := ... // expected to be created
 scheme := ... // scheme registered with all resource types the reconcile interacts with
 
-rts := rtesting.ReconcilerTestSuite{{
-	...
-}, {
-	Name: "creates gateway",
-	Key:  testKey,
-	GivenObjects: []client.Object{
-		inMemoryGateway,
-		inMemoryGatewayImagesConfigMap,
+rts := rtesting.ReconcilerTests{
+	"creates gateway": {
+		Key:  testKey,
+		GivenObjects: []client.Object{
+			inMemoryGateway,
+			inMemoryGatewayImagesConfigMap,
+		},
+		ExpectTracks: []client.Object{
+			rtesting.NewTrackRequest(inMemoryGatewayImagesConfigMap, inMemoryGateway, scheme),
+		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(inMemoryGateway, scheme, corev1.EventTypeNormal, "Created",
+				`Created Gateway "%s"`, testName),
+			rtesting.NewEvent(inMemoryGateway, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
+		},
+		ExpectCreates: []client.Object{
+			gatewayCreate,
+		},
+		ExpectStatusUpdates: []client.Object{
+			// example using an https://dies.dev style die to mutate the resource
+			inMemoryGateway.
+				StatusDie(func(d *diestreamingv1alpha1.InMemoryGatewayStatusDie) {
+					d.ObservedGeneration(1)
+					d.ConditionsDie(
+						// the condition will be unknown since the child resource
+						// was just created and hasn't been reconciled by its
+						// controller yet
+						inMemoryGatewayConditionGatewayReady.Unknown(),
+						inMemoryGatewayConditionReady.Unknown(),
+					)
+				}),
+		},
 	},
-	ExpectTracks: []client.Object{
-		rtesting.NewTrackRequest(inMemoryGatewayImagesConfigMap, inMemoryGateway, scheme),
-	},
-	ExpectEvents: []rtesting.Event{
-		rtesting.NewEvent(inMemoryGateway, scheme, corev1.EventTypeNormal, "Created",
-			`Created Gateway "%s"`, testName),
-		rtesting.NewEvent(inMemoryGateway, scheme, corev1.EventTypeNormal, "StatusUpdated",
-			`Updated status`),
-	},
-	ExpectCreates: []client.Object{
-		gatewayCreate,
-	},
-	ExpectStatusUpdates: []client.Object{
-		// example using an https://dies.dev style die to mutate the resource
-		inMemoryGateway.
-			StatusDie(func(d *diestreamingv1alpha1.InMemoryGatewayStatusDie) {
-				d.ObservedGeneration(1)
-				d.ConditionsDie(
-					// the condition will be unknown since the child resource
-					// was just created and hasn't been reconciled by its
-					// controller yet
-					inMemoryGatewayConditionGatewayReady.Unknown(),
-					inMemoryGatewayConditionReady.Unknown(),
-				)
-			}),
-	},
-}, {
 	...
 }}
 
@@ -540,13 +540,17 @@ rts.Test(t, scheme, func(t *testing.T, rtc *rtesting.ReconcilerTestCase, c recon
 ```
 [full source](https://github.com/projectriff/system/blob/4c3b75327bf99cc37b57ba14df4c65d21dc79d28/pkg/controllers/streaming/inmemorygateway_reconciler_test.go#L142-L169)
 
-### SubReconcilerTestSuite
+<a name="subreconcilertestsuite" />
+
+### SubReconcilerTests
 
 For more complex reconcilers, the number of moving parts can make it difficult to fully cover all aspects of the reonciler and handle corner cases and sources of error. The [`SubReconcilerTestCase`](https://pkg.go.dev/github.com/vmware-labs/reconciler-runtime/testing#SubReconcilerTestCase) enables testing a single sub reconciler in isolation from the resource. While very similar to ReconcilerTestCase, these are the differences:
 
 - `Key` is replaced with `Resource` since the resource is not lookedup, but handed to the reconciler. `ExpectResource` is the mutated value of the resource after the reconciler runs.
 - `GivenStashedValues` is a map of stashed value to seed, `ExpectStashedValues` are individually compared with the actual stashed value after the reconciler runs.
 - `ExpectStatusUpdates` is not available
+
+There are two ways to compose a SubReconcilerTestCase either as an unordered set (using [`SubReconcilerTests`](https://pkg.go.dev/github.com/vmware-labs/reconciler-runtime/testing#SubReconcilerTests)) or an order list (using [`SubReconcilerTestSuite`](https://pkg.go.dev/github.com/vmware-labs/reconciler-runtime/testing#SubReconcilerTestSuite)). When using `SubReconcilerTests` the key for each test case is used as the name for that test case.
 
 **Example:**
 
@@ -556,17 +560,15 @@ Like with the tracking example, the processor reconciler in projectriff also loo
 processor := ...
 processorImagesConfigMap := ...
 
-rts := rtesting.SubReconcilerTestSuite{
-	{
-		Name:   "missing images configmap",
+rts := rtesting.SubReconcilerTests{
+	"missing images configmap": {
 		Resource: processor,
 		ExpectTracks: []rtesting.TrackRequest{
 			rtesting.NewTrackRequest(processorImagesConfigMap, processor, scheme),
 		},
 		ShouldErr: true,
 	},
-	{
-		Name:   "stash processor image",
+	"stash processor image": {
 		Resource: processor,
 		GivenObjects: []client.Object{
 			processorImagesConfigMap,
@@ -720,7 +722,7 @@ Deleting a resource that uses finalizers requires the controller to be running.
 
 The [AddFinalizer](https://pkg.go.dev/github.com/vmware-labs/reconciler-runtime/reconcilers#AddFinalizer) and [ClearFinalizer](https://pkg.go.dev/github.com/vmware-labs/reconciler-runtime/reconcilers#ClearFinalizer) functions patch the reconciled resource to update its finalizers. These methods work with [CastResource](#castresource) resources and use the same client the [ResourceReconciler](#resourcereconciler) used to originally load the reconciled resource. They can be called inside [SubReconcilers](#subreconciler) that may use a different client.
 
-When an update is required, only the `.metadata.finalizers` field is patched. The reconciled resource's `.metadata.resourceVersion` is used as an optimistic concurrency lock, and is updated with the value returned from the server. Any error from the server will cause the resource reconciliation to err. When testing with the [SubReconcilerTestSuite](#subreconcilertestsuite), the resource version of the resource defaults to `"999"`, the patch bytes include the resource version and the response increments the reonciled resource's version. For a resource with the default version that patches a finalizer, the expected reconciled resource will have a resource version of `"1000"`.
+When an update is required, only the `.metadata.finalizers` field is patched. The reconciled resource's `.metadata.resourceVersion` is used as an optimistic concurrency lock, and is updated with the value returned from the server. Any error from the server will cause the resource reconciliation to err. When testing with [SubReconcilerTests](#subreconcilertests), the resource version of the resource defaults to `"999"`, the patch bytes include the resource version and the response increments the reonciled resource's version. For a resource with the default version that patches a finalizer, the expected reconciled resource will have a resource version of `"1000"`.
 
 A minimal test case for a sub reconciler that adds a finalizer may look like:
 

--- a/reconcilers/reconcilers_test.go
+++ b/reconcilers/reconcilers_test.go
@@ -57,23 +57,24 @@ func TestConfig_TrackAndGet(t *testing.T) {
 		}).
 		AddData("greeting", "hello")
 
-	rts := rtesting.SubReconcilerTestSuite{{
-		Name:     "track and get",
-		Resource: resource,
-		GivenObjects: []client.Object{
-			configMap,
+	rts := rtesting.SubReconcilerTests{
+		"track and get": {
+			Resource: resource,
+			GivenObjects: []client.Object{
+				configMap,
+			},
+			ExpectTracks: []rtesting.TrackRequest{
+				rtesting.NewTrackRequest(configMap, resource, scheme),
+			},
 		},
-		ExpectTracks: []rtesting.TrackRequest{
-			rtesting.NewTrackRequest(configMap, resource, scheme),
+		"track with not found get": {
+			Resource:  resource,
+			ShouldErr: true,
+			ExpectTracks: []rtesting.TrackRequest{
+				rtesting.NewTrackRequest(configMap, resource, scheme),
+			},
 		},
-	}, {
-		Name:      "track with not found get",
-		Resource:  resource,
-		ShouldErr: true,
-		ExpectTracks: []rtesting.TrackRequest{
-			rtesting.NewTrackRequest(configMap, resource, scheme),
-		},
-	}}
+	}
 
 	// run with typed objects
 	t.Run("typed", func(t *testing.T) {
@@ -140,22 +141,23 @@ func TestResourceReconciler_NoStatus(t *testing.T) {
 			d.AddAnnotation("blah", "blah")
 		})
 
-	rts := rtesting.ReconcilerTestSuite{{
-		Name: "resource exists",
-		Key:  testKey,
-		GivenObjects: []client.Object{
-			resource,
-		},
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return &reconcilers.SyncReconciler{
-					Sync: func(ctx context.Context, resource *resources.TestResourceNoStatus) error {
-						return nil
-					},
-				}
+	rts := rtesting.ReconcilerTests{
+		"resource exists": {
+			Key: testKey,
+			GivenObjects: []client.Object{
+				resource,
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return &reconcilers.SyncReconciler{
+						Sync: func(ctx context.Context, resource *resources.TestResourceNoStatus) error {
+							return nil
+						},
+					}
+				},
 			},
 		},
-	}}
+	}
 	rts.Run(t, scheme, func(t *testing.T, rtc *rtesting.ReconcilerTestCase, c reconcilers.Config) reconcile.Reconciler {
 		return &reconcilers.ResourceReconciler{
 			Type:       &resources.TestResourceNoStatus{},
@@ -181,22 +183,23 @@ func TestResourceReconciler_EmptyStatus(t *testing.T) {
 			d.AddAnnotation("blah", "blah")
 		})
 
-	rts := rtesting.ReconcilerTestSuite{{
-		Name: "resource exists",
-		Key:  testKey,
-		GivenObjects: []client.Object{
-			resource,
-		},
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return &reconcilers.SyncReconciler{
-					Sync: func(ctx context.Context, resource *resources.TestResourceEmptyStatus) error {
-						return nil
-					},
-				}
+	rts := rtesting.ReconcilerTests{
+		"resource exists": {
+			Key: testKey,
+			GivenObjects: []client.Object{
+				resource,
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return &reconcilers.SyncReconciler{
+						Sync: func(ctx context.Context, resource *resources.TestResourceEmptyStatus) error {
+							return nil
+						},
+					}
+				},
 			},
 		},
-	}}
+	}
 	rts.Run(t, scheme, func(t *testing.T, rtc *rtesting.ReconcilerTestCase, c reconcilers.Config) reconcile.Reconciler {
 		return &reconcilers.ResourceReconciler{
 			Type:       &resources.TestResourceEmptyStatus{},
@@ -226,117 +229,118 @@ func TestResourceReconciler_NilableStatus(t *testing.T) {
 			)
 		})
 
-	rts := rtesting.ReconcilerTestSuite{{
-		Name: "nil status",
-		Key:  testKey,
-		GivenObjects: []client.Object{
-			resource.Status(nil),
-		},
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return &reconcilers.SyncReconciler{
-					Sync: func(ctx context.Context, resource *resources.TestResourceNilableStatus) error {
-						if resource.Status != nil {
-							t.Errorf("status expected to be nil")
-						}
-						return nil
-					},
-				}
+	rts := rtesting.ReconcilerTests{
+		"nil status": {
+			Key: testKey,
+			GivenObjects: []client.Object{
+				resource.Status(nil),
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return &reconcilers.SyncReconciler{
+						Sync: func(ctx context.Context, resource *resources.TestResourceNilableStatus) error {
+							if resource.Status != nil {
+								t.Errorf("status expected to be nil")
+							}
+							return nil
+						},
+					}
+				},
 			},
 		},
-	}, {
-		Name: "status conditions are initialized",
-		Key:  testKey,
-		GivenObjects: []client.Object{
-			resource.StatusDie(func(d *dies.TestResourceStatusDie) {
-				d.ConditionsDie()
-			}),
-		},
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return &reconcilers.SyncReconciler{
-					Sync: func(ctx context.Context, resource *resources.TestResourceNilableStatus) error {
-						expected := []metav1.Condition{
-							{Type: apis.ConditionReady, Status: metav1.ConditionUnknown, Reason: "Initializing"},
-						}
-						if diff := cmp.Diff(expected, resource.Status.Conditions, rtesting.IgnoreLastTransitionTime); diff != "" {
-							t.Errorf("Unexpected condition (-expected, +actual): %s", diff)
-						}
-						return nil
-					},
-				}
+		"status conditions are initialized": {
+			Key: testKey,
+			GivenObjects: []client.Object{
+				resource.StatusDie(func(d *dies.TestResourceStatusDie) {
+					d.ConditionsDie()
+				}),
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return &reconcilers.SyncReconciler{
+						Sync: func(ctx context.Context, resource *resources.TestResourceNilableStatus) error {
+							expected := []metav1.Condition{
+								{Type: apis.ConditionReady, Status: metav1.ConditionUnknown, Reason: "Initializing"},
+							}
+							if diff := cmp.Diff(expected, resource.Status.Conditions, rtesting.IgnoreLastTransitionTime); diff != "" {
+								t.Errorf("Unexpected condition (-expected, +actual): %s", diff)
+							}
+							return nil
+						},
+					}
+				},
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "StatusUpdated",
+					`Updated status`),
+			},
+			ExpectStatusUpdates: []client.Object{
+				resource,
 			},
 		},
-		ExpectEvents: []rtesting.Event{
-			rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "StatusUpdated",
-				`Updated status`),
-		},
-		ExpectStatusUpdates: []client.Object{
-			resource,
-		},
-	}, {
-		Name: "reconciler mutated status",
-		Key:  testKey,
-		GivenObjects: []client.Object{
-			resource,
-		},
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return &reconcilers.SyncReconciler{
-					Sync: func(ctx context.Context, resource *resources.TestResourceNilableStatus) error {
-						if resource.Status.Fields == nil {
-							resource.Status.Fields = map[string]string{}
-						}
-						resource.Status.Fields["Reconciler"] = "ran"
-						return nil
-					},
-				}
+		"reconciler mutated status": {
+			Key: testKey,
+			GivenObjects: []client.Object{
+				resource,
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return &reconcilers.SyncReconciler{
+						Sync: func(ctx context.Context, resource *resources.TestResourceNilableStatus) error {
+							if resource.Status.Fields == nil {
+								resource.Status.Fields = map[string]string{}
+							}
+							resource.Status.Fields["Reconciler"] = "ran"
+							return nil
+						},
+					}
+				},
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "StatusUpdated",
+					`Updated status`),
+			},
+			ExpectStatusUpdates: []client.Object{
+				resource.StatusDie(func(d *dies.TestResourceStatusDie) {
+					d.AddField("Reconciler", "ran")
+				}),
 			},
 		},
-		ExpectEvents: []rtesting.Event{
-			rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "StatusUpdated",
-				`Updated status`),
-		},
-		ExpectStatusUpdates: []client.Object{
-			resource.StatusDie(func(d *dies.TestResourceStatusDie) {
-				d.AddField("Reconciler", "ran")
-			}),
-		},
-	}, {
-		Name: "status update failed",
-		Key:  testKey,
-		GivenObjects: []client.Object{
-			resource,
-		},
-		WithReactors: []rtesting.ReactionFunc{
-			rtesting.InduceFailure("update", "TestResourceNilableStatus", rtesting.InduceFailureOpts{
-				SubResource: "status",
-			}),
-		},
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return &reconcilers.SyncReconciler{
-					Sync: func(ctx context.Context, resource *resources.TestResourceNilableStatus) error {
-						if resource.Status.Fields == nil {
-							resource.Status.Fields = map[string]string{}
-						}
-						resource.Status.Fields["Reconciler"] = "ran"
-						return nil
-					},
-				}
+		"status update failed": {
+			Key: testKey,
+			GivenObjects: []client.Object{
+				resource,
 			},
+			WithReactors: []rtesting.ReactionFunc{
+				rtesting.InduceFailure("update", "TestResourceNilableStatus", rtesting.InduceFailureOpts{
+					SubResource: "status",
+				}),
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return &reconcilers.SyncReconciler{
+						Sync: func(ctx context.Context, resource *resources.TestResourceNilableStatus) error {
+							if resource.Status.Fields == nil {
+								resource.Status.Fields = map[string]string{}
+							}
+							resource.Status.Fields["Reconciler"] = "ran"
+							return nil
+						},
+					}
+				},
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeWarning, "StatusUpdateFailed",
+					`Failed to update status: inducing failure for update TestResourceNilableStatus`),
+			},
+			ExpectStatusUpdates: []client.Object{
+				resource.StatusDie(func(d *dies.TestResourceStatusDie) {
+					d.AddField("Reconciler", "ran")
+				}),
+			},
+			ShouldErr: true,
 		},
-		ExpectEvents: []rtesting.Event{
-			rtesting.NewEvent(resource, scheme, corev1.EventTypeWarning, "StatusUpdateFailed",
-				`Failed to update status: inducing failure for update TestResourceNilableStatus`),
-		},
-		ExpectStatusUpdates: []client.Object{
-			resource.StatusDie(func(d *dies.TestResourceStatusDie) {
-				d.AddField("Reconciler", "ran")
-			}),
-		},
-		ShouldErr: true,
-	}}
+	}
 
 	rts.Run(t, scheme, func(t *testing.T, rtc *rtesting.ReconcilerTestCase, c reconcilers.Config) reconcile.Reconciler {
 		return &reconcilers.ResourceReconciler{
@@ -368,244 +372,245 @@ func TestResourceReconciler(t *testing.T) {
 		})
 	deletedAt := metav1.NewTime(time.UnixMilli(2000))
 
-	rts := rtesting.ReconcilerTestSuite{{
-		Name: "resource does not exist",
-		Key:  testKey,
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return &reconcilers.SyncReconciler{
-					Sync: func(ctx context.Context, resource *resources.TestResource) error {
-						t.Error("should not be called")
-						return nil
-					},
-				}
+	rts := rtesting.ReconcilerTests{
+		"resource does not exist": {
+			Key: testKey,
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return &reconcilers.SyncReconciler{
+						Sync: func(ctx context.Context, resource *resources.TestResource) error {
+							t.Error("should not be called")
+							return nil
+						},
+					}
+				},
 			},
 		},
-	}, {
-		Name: "ignore deleted resource",
-		Key:  testKey,
-		GivenObjects: []client.Object{
-			resource.MetadataDie(func(d *diemetav1.ObjectMetaDie) {
-				d.DeletionTimestamp(&deletedAt)
-			}),
-		},
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return &reconcilers.SyncReconciler{
-					Sync: func(ctx context.Context, resource *resources.TestResource) error {
-						t.Error("should not be called")
-						return nil
-					},
-				}
+		"ignore deleted resource": {
+			Key: testKey,
+			GivenObjects: []client.Object{
+				resource.MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+					d.DeletionTimestamp(&deletedAt)
+				}),
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return &reconcilers.SyncReconciler{
+						Sync: func(ctx context.Context, resource *resources.TestResource) error {
+							t.Error("should not be called")
+							return nil
+						},
+					}
+				},
 			},
 		},
-	}, {
-		Name: "error fetching resource",
-		Key:  testKey,
-		GivenObjects: []client.Object{
-			resource,
+		"error fetching resource": {
+			Key: testKey,
+			GivenObjects: []client.Object{
+				resource,
+			},
+			WithReactors: []rtesting.ReactionFunc{
+				rtesting.InduceFailure("get", "TestResource"),
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return &reconcilers.SyncReconciler{
+						Sync: func(ctx context.Context, resource *resources.TestResource) error {
+							t.Error("should not be called")
+							return nil
+						},
+					}
+				},
+			},
+			ShouldErr: true,
 		},
-		WithReactors: []rtesting.ReactionFunc{
-			rtesting.InduceFailure("get", "TestResource"),
-		},
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return &reconcilers.SyncReconciler{
-					Sync: func(ctx context.Context, resource *resources.TestResource) error {
-						t.Error("should not be called")
-						return nil
-					},
-				}
+		"resource is defaulted": {
+			Key: testKey,
+			GivenObjects: []client.Object{
+				resource,
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return &reconcilers.SyncReconciler{
+						Sync: func(ctx context.Context, resource *resources.TestResource) error {
+							if expected, actual := "ran", resource.Spec.Fields["Defaulter"]; expected != actual {
+								t.Errorf("unexpected default value, actually = %v, expected = %v", expected, actual)
+							}
+							return nil
+						},
+					}
+				},
 			},
 		},
-		ShouldErr: true,
-	}, {
-		Name: "resource is defaulted",
-		Key:  testKey,
-		GivenObjects: []client.Object{
-			resource,
-		},
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return &reconcilers.SyncReconciler{
-					Sync: func(ctx context.Context, resource *resources.TestResource) error {
-						if expected, actual := "ran", resource.Spec.Fields["Defaulter"]; expected != actual {
-							t.Errorf("unexpected default value, actually = %v, expected = %v", expected, actual)
-						}
-						return nil
-					},
-				}
+		"status conditions are initialized": {
+			Key: testKey,
+			GivenObjects: []client.Object{
+				resource.StatusDie(func(d *dies.TestResourceStatusDie) {
+					d.ConditionsDie()
+				}),
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return &reconcilers.SyncReconciler{
+						Sync: func(ctx context.Context, resource *resources.TestResource) error {
+							expected := []metav1.Condition{
+								{Type: apis.ConditionReady, Status: metav1.ConditionUnknown, Reason: "Initializing"},
+							}
+							if diff := cmp.Diff(expected, resource.Status.Conditions, rtesting.IgnoreLastTransitionTime); diff != "" {
+								t.Errorf("Unexpected condition (-expected, +actual): %s", diff)
+							}
+							return nil
+						},
+					}
+				},
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "StatusUpdated",
+					`Updated status`),
+			},
+			ExpectStatusUpdates: []client.Object{
+				resource,
 			},
 		},
-	}, {
-		Name: "status conditions are initialized",
-		Key:  testKey,
-		GivenObjects: []client.Object{
-			resource.StatusDie(func(d *dies.TestResourceStatusDie) {
-				d.ConditionsDie()
-			}),
-		},
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return &reconcilers.SyncReconciler{
-					Sync: func(ctx context.Context, resource *resources.TestResource) error {
-						expected := []metav1.Condition{
-							{Type: apis.ConditionReady, Status: metav1.ConditionUnknown, Reason: "Initializing"},
-						}
-						if diff := cmp.Diff(expected, resource.Status.Conditions, rtesting.IgnoreLastTransitionTime); diff != "" {
-							t.Errorf("Unexpected condition (-expected, +actual): %s", diff)
-						}
-						return nil
-					},
-				}
+		"reconciler mutated status": {
+			Key: testKey,
+			GivenObjects: []client.Object{
+				resource,
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return &reconcilers.SyncReconciler{
+						Sync: func(ctx context.Context, resource *resources.TestResource) error {
+							if resource.Status.Fields == nil {
+								resource.Status.Fields = map[string]string{}
+							}
+							resource.Status.Fields["Reconciler"] = "ran"
+							return nil
+						},
+					}
+				},
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "StatusUpdated",
+					`Updated status`),
+			},
+			ExpectStatusUpdates: []client.Object{
+				resource.StatusDie(func(d *dies.TestResourceStatusDie) {
+					d.AddField("Reconciler", "ran")
+				}),
 			},
 		},
-		ExpectEvents: []rtesting.Event{
-			rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "StatusUpdated",
-				`Updated status`),
+		"sub reconciler erred": {
+			Key: testKey,
+			GivenObjects: []client.Object{
+				resource,
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return &reconcilers.SyncReconciler{
+						Sync: func(ctx context.Context, resource *resources.TestResource) error {
+							return fmt.Errorf("reconciler error")
+						},
+					}
+				},
+			},
+			ShouldErr: true,
 		},
-		ExpectStatusUpdates: []client.Object{
-			resource,
+		"status update failed": {
+			Key: testKey,
+			GivenObjects: []client.Object{
+				resource,
+			},
+			WithReactors: []rtesting.ReactionFunc{
+				rtesting.InduceFailure("update", "TestResource", rtesting.InduceFailureOpts{
+					SubResource: "status",
+				}),
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return &reconcilers.SyncReconciler{
+						Sync: func(ctx context.Context, resource *resources.TestResource) error {
+							if resource.Status.Fields == nil {
+								resource.Status.Fields = map[string]string{}
+							}
+							resource.Status.Fields["Reconciler"] = "ran"
+							return nil
+						},
+					}
+				},
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeWarning, "StatusUpdateFailed",
+					`Failed to update status: inducing failure for update TestResource`),
+			},
+			ExpectStatusUpdates: []client.Object{
+				resource.StatusDie(func(d *dies.TestResourceStatusDie) {
+					d.AddField("Reconciler", "ran")
+				}),
+			},
+			ShouldErr: true,
 		},
-	}, {
-		Name: "reconciler mutated status",
-		Key:  testKey,
-		GivenObjects: []client.Object{
-			resource,
-		},
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return &reconcilers.SyncReconciler{
-					Sync: func(ctx context.Context, resource *resources.TestResource) error {
-						if resource.Status.Fields == nil {
-							resource.Status.Fields = map[string]string{}
-						}
-						resource.Status.Fields["Reconciler"] = "ran"
-						return nil
-					},
-				}
+		"context is stashable": {
+			Key: testKey,
+			GivenObjects: []client.Object{
+				resource,
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return &reconcilers.SyncReconciler{
+						Sync: func(ctx context.Context, resource *resources.TestResource) error {
+							var key reconcilers.StashKey = "foo"
+							// StashValue will panic if the context is not setup correctly
+							reconcilers.StashValue(ctx, key, "bar")
+							return nil
+						},
+					}
+				},
 			},
 		},
-		ExpectEvents: []rtesting.Event{
-			rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "StatusUpdated",
-				`Updated status`),
-		},
-		ExpectStatusUpdates: []client.Object{
-			resource.StatusDie(func(d *dies.TestResourceStatusDie) {
-				d.AddField("Reconciler", "ran")
-			}),
-		},
-	}, {
-		Name: "sub reconciler erred",
-		Key:  testKey,
-		GivenObjects: []client.Object{
-			resource,
-		},
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return &reconcilers.SyncReconciler{
-					Sync: func(ctx context.Context, resource *resources.TestResource) error {
-						return fmt.Errorf("reconciler error")
-					},
-				}
+		"context has config": {
+			Key: testKey,
+			GivenObjects: []client.Object{
+				resource,
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return &reconcilers.SyncReconciler{
+						Sync: func(ctx context.Context, resource *resources.TestResource) error {
+							if config := reconcilers.RetrieveConfigOrDie(ctx); config != c {
+								t.Errorf("expected config in context, found %#v", config)
+							}
+							if resourceConfig := reconcilers.RetrieveOriginalConfigOrDie(ctx); resourceConfig != c {
+								t.Errorf("expected original config in context, found %#v", resourceConfig)
+							}
+							return nil
+						},
+					}
+				},
 			},
 		},
-		ShouldErr: true,
-	}, {
-		Name: "status update failed",
-		Key:  testKey,
-		GivenObjects: []client.Object{
-			resource,
-		},
-		WithReactors: []rtesting.ReactionFunc{
-			rtesting.InduceFailure("update", "TestResource", rtesting.InduceFailureOpts{
-				SubResource: "status",
-			}),
-		},
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return &reconcilers.SyncReconciler{
-					Sync: func(ctx context.Context, resource *resources.TestResource) error {
-						if resource.Status.Fields == nil {
-							resource.Status.Fields = map[string]string{}
-						}
-						resource.Status.Fields["Reconciler"] = "ran"
-						return nil
-					},
-				}
+		"context has resource type": {
+			Key: testKey,
+			GivenObjects: []client.Object{
+				resource,
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return &reconcilers.SyncReconciler{
+						Sync: func(ctx context.Context, resource *resources.TestResource) error {
+							if resourceType, ok := reconcilers.RetrieveOriginalResourceType(ctx).(*resources.TestResource); !ok {
+								t.Errorf("expected original resource type not in context, found %#v", resourceType)
+							}
+							if resourceType, ok := reconcilers.RetrieveResourceType(ctx).(*resources.TestResource); !ok {
+								t.Errorf("expected resource type not in context, found %#v", resourceType)
+							}
+							return nil
+						},
+					}
+				},
 			},
 		},
-		ExpectEvents: []rtesting.Event{
-			rtesting.NewEvent(resource, scheme, corev1.EventTypeWarning, "StatusUpdateFailed",
-				`Failed to update status: inducing failure for update TestResource`),
-		},
-		ExpectStatusUpdates: []client.Object{
-			resource.StatusDie(func(d *dies.TestResourceStatusDie) {
-				d.AddField("Reconciler", "ran")
-			}),
-		},
-		ShouldErr: true,
-	}, {
-		Name: "context is stashable",
-		Key:  testKey,
-		GivenObjects: []client.Object{
-			resource,
-		},
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return &reconcilers.SyncReconciler{
-					Sync: func(ctx context.Context, resource *resources.TestResource) error {
-						var key reconcilers.StashKey = "foo"
-						// StashValue will panic if the context is not setup correctly
-						reconcilers.StashValue(ctx, key, "bar")
-						return nil
-					},
-				}
-			},
-		},
-	}, {
-		Name: "context has config",
-		Key:  testKey,
-		GivenObjects: []client.Object{
-			resource,
-		},
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return &reconcilers.SyncReconciler{
-					Sync: func(ctx context.Context, resource *resources.TestResource) error {
-						if config := reconcilers.RetrieveConfigOrDie(ctx); config != c {
-							t.Errorf("expected config in context, found %#v", config)
-						}
-						if resourceConfig := reconcilers.RetrieveOriginalConfigOrDie(ctx); resourceConfig != c {
-							t.Errorf("expected original config in context, found %#v", resourceConfig)
-						}
-						return nil
-					},
-				}
-			},
-		},
-	}, {
-		Name: "context has resource type",
-		Key:  testKey,
-		GivenObjects: []client.Object{
-			resource,
-		},
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return &reconcilers.SyncReconciler{
-					Sync: func(ctx context.Context, resource *resources.TestResource) error {
-						if resourceType, ok := reconcilers.RetrieveOriginalResourceType(ctx).(*resources.TestResource); !ok {
-							t.Errorf("expected original resource type not in context, found %#v", resourceType)
-						}
-						if resourceType, ok := reconcilers.RetrieveResourceType(ctx).(*resources.TestResource); !ok {
-							t.Errorf("expected resource type not in context, found %#v", resourceType)
-						}
-						return nil
-					},
-				}
-			},
-		},
-	}}
+	}
 
 	rts.Run(t, scheme, func(t *testing.T, rtc *rtesting.ReconcilerTestCase, c reconcilers.Config) reconcile.Reconciler {
 		return &reconcilers.ResourceReconciler{
@@ -659,340 +664,341 @@ func TestAggregateReconciler(t *testing.T) {
 		}
 	}
 
-	rts := rtesting.ReconcilerTestSuite{{
-		Name: "resource is in sync",
-		Key:  key,
-		GivenObjects: []client.Object{
-			configMapGiven.
-				AddData("foo", "bar"),
-		},
-		Metadata: map[string]interface{}{
-			"Reconciler": func(t *testing.T, c reconcilers.Config) reconcile.Reconciler {
-				return defaultAggregateReconciler(c)
+	rts := rtesting.ReconcilerTests{
+		"resource is in sync": {
+			Key: key,
+			GivenObjects: []client.Object{
+				configMapGiven.
+					AddData("foo", "bar"),
+			},
+			Metadata: map[string]interface{}{
+				"Reconciler": func(t *testing.T, c reconcilers.Config) reconcile.Reconciler {
+					return defaultAggregateReconciler(c)
+				},
 			},
 		},
-	}, {
-		Name: "ignore other resources",
-		Key:  types.NamespacedName{Namespace: testName, Name: "not-it"},
-		Metadata: map[string]interface{}{
-			"Reconciler": func(t *testing.T, c reconcilers.Config) reconcile.Reconciler {
-				return defaultAggregateReconciler(c)
+		"ignore other resources": {
+			Key: types.NamespacedName{Namespace: testName, Name: "not-it"},
+			Metadata: map[string]interface{}{
+				"Reconciler": func(t *testing.T, c reconcilers.Config) reconcile.Reconciler {
+					return defaultAggregateReconciler(c)
+				},
 			},
 		},
-	}, {
-		Name: "ignore terminating resources",
-		Key:  key,
-		GivenObjects: []client.Object{
-			configMapGiven.
-				MetadataDie(func(d *diemetav1.ObjectMetaDie) {
-					d.DeletionTimestamp(&now)
-				}),
-		},
-		Metadata: map[string]interface{}{
-			"Reconciler": func(t *testing.T, c reconcilers.Config) reconcile.Reconciler {
-				return defaultAggregateReconciler(c)
+		"ignore terminating resources": {
+			Key: key,
+			GivenObjects: []client.Object{
+				configMapGiven.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.DeletionTimestamp(&now)
+					}),
+			},
+			Metadata: map[string]interface{}{
+				"Reconciler": func(t *testing.T, c reconcilers.Config) reconcile.Reconciler {
+					return defaultAggregateReconciler(c)
+				},
 			},
 		},
-	}, {
-		Name: "create resource",
-		Key:  key,
-		Metadata: map[string]interface{}{
-			"Reconciler": func(t *testing.T, c reconcilers.Config) reconcile.Reconciler {
-				return defaultAggregateReconciler(c)
+		"create resource": {
+			Key: key,
+			Metadata: map[string]interface{}{
+				"Reconciler": func(t *testing.T, c reconcilers.Config) reconcile.Reconciler {
+					return defaultAggregateReconciler(c)
+				},
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(configMapGiven, scheme, corev1.EventTypeNormal, "Created",
+					`Created ConfigMap %q`, testName),
+			},
+			ExpectCreates: []client.Object{
+				configMapCreate.
+					AddData("foo", "bar"),
 			},
 		},
-		ExpectEvents: []rtesting.Event{
-			rtesting.NewEvent(configMapGiven, scheme, corev1.EventTypeNormal, "Created",
-				`Created ConfigMap %q`, testName),
-		},
-		ExpectCreates: []client.Object{
-			configMapCreate.
-				AddData("foo", "bar"),
-		},
-	}, {
-		Name: "update resource",
-		Key:  key,
-		GivenObjects: []client.Object{
-			configMapGiven,
-		},
-		Metadata: map[string]interface{}{
-			"Reconciler": func(t *testing.T, c reconcilers.Config) reconcile.Reconciler {
-				return defaultAggregateReconciler(c)
+		"update resource": {
+			Key: key,
+			GivenObjects: []client.Object{
+				configMapGiven,
+			},
+			Metadata: map[string]interface{}{
+				"Reconciler": func(t *testing.T, c reconcilers.Config) reconcile.Reconciler {
+					return defaultAggregateReconciler(c)
+				},
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(configMapGiven, scheme, corev1.EventTypeNormal, "Updated",
+					`Updated ConfigMap %q`, testName),
+			},
+			ExpectUpdates: []client.Object{
+				configMapGiven.
+					AddData("foo", "bar"),
 			},
 		},
-		ExpectEvents: []rtesting.Event{
-			rtesting.NewEvent(configMapGiven, scheme, corev1.EventTypeNormal, "Updated",
-				`Updated ConfigMap %q`, testName),
-		},
-		ExpectUpdates: []client.Object{
-			configMapGiven.
-				AddData("foo", "bar"),
-		},
-	}, {
-		Name: "delete resource",
-		Key:  key,
-		GivenObjects: []client.Object{
-			configMapGiven,
-		},
-		Metadata: map[string]interface{}{
-			"Reconciler": func(t *testing.T, c reconcilers.Config) reconcile.Reconciler {
-				r := defaultAggregateReconciler(c)
-				r.DesiredResource = func(ctx context.Context, resource client.Object) (client.Object, error) {
-					return nil, nil
-				}
-				return r
+		"delete resource": {
+			Key: key,
+			GivenObjects: []client.Object{
+				configMapGiven,
+			},
+			Metadata: map[string]interface{}{
+				"Reconciler": func(t *testing.T, c reconcilers.Config) reconcile.Reconciler {
+					r := defaultAggregateReconciler(c)
+					r.DesiredResource = func(ctx context.Context, resource client.Object) (client.Object, error) {
+						return nil, nil
+					}
+					return r
+				},
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(configMapGiven, scheme, corev1.EventTypeNormal, "Deleted",
+					`Deleted ConfigMap %q`, testName),
+			},
+			ExpectDeletes: []rtesting.DeleteRef{
+				rtesting.NewDeleteRefFromObject(configMapGiven, scheme),
 			},
 		},
-		ExpectEvents: []rtesting.Event{
-			rtesting.NewEvent(configMapGiven, scheme, corev1.EventTypeNormal, "Deleted",
-				`Deleted ConfigMap %q`, testName),
-		},
-		ExpectDeletes: []rtesting.DeleteRef{
-			rtesting.NewDeleteRefFromObject(configMapGiven, scheme),
-		},
-	}, {
-		Name: "preserve immutable fields",
-		Key:  key,
-		GivenObjects: []client.Object{
-			configMapGiven.
-				AddData("foo", "bar").
-				AddData("immutable", "field"),
-		},
-		Metadata: map[string]interface{}{
-			"Reconciler": func(t *testing.T, c reconcilers.Config) reconcile.Reconciler {
-				r := defaultAggregateReconciler(c)
-				r.HarmonizeImmutableFields = func(current, desired *corev1.ConfigMap) {
-					desired.Data["immutable"] = current.Data["immutable"]
-				}
-				return r
+		"preserve immutable fields": {
+			Key: key,
+			GivenObjects: []client.Object{
+				configMapGiven.
+					AddData("foo", "bar").
+					AddData("immutable", "field"),
+			},
+			Metadata: map[string]interface{}{
+				"Reconciler": func(t *testing.T, c reconcilers.Config) reconcile.Reconciler {
+					r := defaultAggregateReconciler(c)
+					r.HarmonizeImmutableFields = func(current, desired *corev1.ConfigMap) {
+						desired.Data["immutable"] = current.Data["immutable"]
+					}
+					return r
+				},
 			},
 		},
-	}, {
-		Name: "sanitize resource before logging",
-		Key:  key,
-		Metadata: map[string]interface{}{
-			"Reconciler": func(t *testing.T, c reconcilers.Config) reconcile.Reconciler {
-				r := defaultAggregateReconciler(c)
-				r.Sanitize = func(child *corev1.ConfigMap) interface{} {
-					return child.Name
-				}
-				return r
+		"sanitize resource before logging": {
+			Key: key,
+			Metadata: map[string]interface{}{
+				"Reconciler": func(t *testing.T, c reconcilers.Config) reconcile.Reconciler {
+					r := defaultAggregateReconciler(c)
+					r.Sanitize = func(child *corev1.ConfigMap) interface{} {
+						return child.Name
+					}
+					return r
+				},
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(configMapGiven, scheme, corev1.EventTypeNormal, "Created",
+					`Created ConfigMap %q`, testName),
+			},
+			ExpectCreates: []client.Object{
+				configMapCreate.
+					AddData("foo", "bar"),
 			},
 		},
-		ExpectEvents: []rtesting.Event{
-			rtesting.NewEvent(configMapGiven, scheme, corev1.EventTypeNormal, "Created",
-				`Created ConfigMap %q`, testName),
-		},
-		ExpectCreates: []client.Object{
-			configMapCreate.
-				AddData("foo", "bar"),
-		},
-	}, {
-		Name: "sanitize is mutation safe",
-		Key:  key,
-		Metadata: map[string]interface{}{
-			"Reconciler": func(t *testing.T, c reconcilers.Config) reconcile.Reconciler {
-				r := defaultAggregateReconciler(c)
-				r.Sanitize = func(child *corev1.ConfigMap) interface{} {
-					child.Data["ignore"] = "me"
-					return child
-				}
-				return r
+		"sanitize is mutation safe": {
+			Key: key,
+			Metadata: map[string]interface{}{
+				"Reconciler": func(t *testing.T, c reconcilers.Config) reconcile.Reconciler {
+					r := defaultAggregateReconciler(c)
+					r.Sanitize = func(child *corev1.ConfigMap) interface{} {
+						child.Data["ignore"] = "me"
+						return child
+					}
+					return r
+				},
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(configMapGiven, scheme, corev1.EventTypeNormal, "Created",
+					`Created ConfigMap %q`, testName),
+			},
+			ExpectCreates: []client.Object{
+				configMapCreate.
+					AddData("foo", "bar"),
 			},
 		},
-		ExpectEvents: []rtesting.Event{
-			rtesting.NewEvent(configMapGiven, scheme, corev1.EventTypeNormal, "Created",
-				`Created ConfigMap %q`, testName),
+		"error getting resources": {
+			Key: key,
+			WithReactors: []rtesting.ReactionFunc{
+				rtesting.InduceFailure("get", "ConfigMap"),
+			},
+			Metadata: map[string]interface{}{
+				"Reconciler": func(t *testing.T, c reconcilers.Config) reconcile.Reconciler {
+					return defaultAggregateReconciler(c)
+				},
+			},
+			ShouldErr: true,
 		},
-		ExpectCreates: []client.Object{
-			configMapCreate.
-				AddData("foo", "bar"),
+		"error creating resource": {
+			Key: key,
+			WithReactors: []rtesting.ReactionFunc{
+				rtesting.InduceFailure("create", "ConfigMap"),
+			},
+			Metadata: map[string]interface{}{
+				"Reconciler": func(t *testing.T, c reconcilers.Config) reconcile.Reconciler {
+					return defaultAggregateReconciler(c)
+				},
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(configMapGiven, scheme, corev1.EventTypeWarning, "CreationFailed",
+					`Failed to create ConfigMap %q: inducing failure for create ConfigMap`, testName),
+			},
+			ExpectCreates: []client.Object{
+				configMapCreate.
+					AddData("foo", "bar"),
+			},
+			ShouldErr: true,
 		},
-	}, {
-		Name: "error getting resources",
-		Key:  key,
-		WithReactors: []rtesting.ReactionFunc{
-			rtesting.InduceFailure("get", "ConfigMap"),
+		"error updating resource": {
+			Key: key,
+			GivenObjects: []client.Object{
+				configMapGiven,
+			},
+			WithReactors: []rtesting.ReactionFunc{
+				rtesting.InduceFailure("update", "ConfigMap"),
+			},
+			Metadata: map[string]interface{}{
+				"Reconciler": func(t *testing.T, c reconcilers.Config) reconcile.Reconciler {
+					return defaultAggregateReconciler(c)
+				},
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(configMapGiven, scheme, corev1.EventTypeWarning, "UpdateFailed",
+					`Failed to update ConfigMap %q: inducing failure for update ConfigMap`, testName),
+			},
+			ExpectUpdates: []client.Object{
+				configMapGiven.
+					AddData("foo", "bar"),
+			},
+			ShouldErr: true,
 		},
-		Metadata: map[string]interface{}{
-			"Reconciler": func(t *testing.T, c reconcilers.Config) reconcile.Reconciler {
-				return defaultAggregateReconciler(c)
+		"error deleting resource": {
+			Key: key,
+			GivenObjects: []client.Object{
+				configMapGiven,
+			},
+			WithReactors: []rtesting.ReactionFunc{
+				rtesting.InduceFailure("delete", "ConfigMap"),
+			},
+			Metadata: map[string]interface{}{
+				"Reconciler": func(t *testing.T, c reconcilers.Config) reconcile.Reconciler {
+					r := defaultAggregateReconciler(c)
+					r.DesiredResource = func(ctx context.Context, resource client.Object) (client.Object, error) {
+						return nil, nil
+					}
+					return r
+				},
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(configMapGiven, scheme, corev1.EventTypeWarning, "DeleteFailed",
+					`Failed to delete ConfigMap %q: inducing failure for delete ConfigMap`, testName),
+			},
+			ExpectDeletes: []rtesting.DeleteRef{
+				rtesting.NewDeleteRefFromObject(configMapGiven, scheme),
+			},
+			ShouldErr: true,
+		},
+		"reconcile result": {
+			Key: key,
+			GivenObjects: []client.Object{
+				configMapGiven.
+					AddData("foo", "bar"),
+			},
+			Metadata: map[string]interface{}{
+				"Reconciler": func(t *testing.T, c reconcilers.Config) reconcile.Reconciler {
+					r := defaultAggregateReconciler(c)
+					r.Reconciler = &reconcilers.SyncReconciler{
+						Sync: func(ctx context.Context, resource client.Object) (ctrl.Result, error) {
+							return ctrl.Result{RequeueAfter: time.Hour}, nil
+						},
+					}
+					return r
+				},
+			},
+			ExpectedResult: ctrl.Result{RequeueAfter: time.Hour},
+		},
+		"reconcile error": {
+			Key: key,
+			Metadata: map[string]interface{}{
+				"Reconciler": func(t *testing.T, c reconcilers.Config) reconcile.Reconciler {
+					r := defaultAggregateReconciler(c)
+					r.Reconciler = &reconcilers.SyncReconciler{
+						Sync: func(ctx context.Context, resource client.Object) error {
+							return fmt.Errorf("test error")
+						},
+					}
+					return r
+				},
+			},
+			ShouldErr: true,
+		},
+		"context is stashable": {
+			Key: key,
+			GivenObjects: []client.Object{
+				configMapGiven.
+					AddData("foo", "bar"),
+			},
+			Metadata: map[string]interface{}{
+				"Reconciler": func(t *testing.T, c reconcilers.Config) reconcile.Reconciler {
+					r := defaultAggregateReconciler(c)
+					r.Reconciler = &reconcilers.SyncReconciler{
+						Sync: func(ctx context.Context, resource *corev1.ConfigMap) error {
+							var key reconcilers.StashKey = "foo"
+							// StashValue will panic if the context is not setup correctly
+							reconcilers.StashValue(ctx, key, "bar")
+							return nil
+						},
+					}
+					return r
+				},
 			},
 		},
-		ShouldErr: true,
-	}, {
-		Name: "error creating resource",
-		Key:  key,
-		WithReactors: []rtesting.ReactionFunc{
-			rtesting.InduceFailure("create", "ConfigMap"),
-		},
-		Metadata: map[string]interface{}{
-			"Reconciler": func(t *testing.T, c reconcilers.Config) reconcile.Reconciler {
-				return defaultAggregateReconciler(c)
+		"context has config": {
+			Key: key,
+			GivenObjects: []client.Object{
+				configMapGiven.
+					AddData("foo", "bar"),
+			},
+			Metadata: map[string]interface{}{
+				"Reconciler": func(t *testing.T, c reconcilers.Config) reconcile.Reconciler {
+					r := defaultAggregateReconciler(c)
+					r.Reconciler = &reconcilers.SyncReconciler{
+						Sync: func(ctx context.Context, resource *corev1.ConfigMap) error {
+							if config := reconcilers.RetrieveConfigOrDie(ctx); config != c {
+								t.Errorf("expected config in context, found %#v", config)
+							}
+							if resourceConfig := reconcilers.RetrieveOriginalConfigOrDie(ctx); resourceConfig != c {
+								t.Errorf("expected original config in context, found %#v", resourceConfig)
+							}
+							return nil
+						},
+					}
+					return r
+				},
 			},
 		},
-		ExpectEvents: []rtesting.Event{
-			rtesting.NewEvent(configMapGiven, scheme, corev1.EventTypeWarning, "CreationFailed",
-				`Failed to create ConfigMap %q: inducing failure for create ConfigMap`, testName),
-		},
-		ExpectCreates: []client.Object{
-			configMapCreate.
-				AddData("foo", "bar"),
-		},
-		ShouldErr: true,
-	}, {
-		Name: "error updating resource",
-		Key:  key,
-		GivenObjects: []client.Object{
-			configMapGiven,
-		},
-		WithReactors: []rtesting.ReactionFunc{
-			rtesting.InduceFailure("update", "ConfigMap"),
-		},
-		Metadata: map[string]interface{}{
-			"Reconciler": func(t *testing.T, c reconcilers.Config) reconcile.Reconciler {
-				return defaultAggregateReconciler(c)
+		"context has resource type": {
+			Key: key,
+			GivenObjects: []client.Object{
+				configMapGiven.
+					AddData("foo", "bar"),
+			},
+			Metadata: map[string]interface{}{
+				"Reconciler": func(t *testing.T, c reconcilers.Config) reconcile.Reconciler {
+					r := defaultAggregateReconciler(c)
+					r.Reconciler = &reconcilers.SyncReconciler{
+						Sync: func(ctx context.Context, resource *corev1.ConfigMap) error {
+							if resourceType, ok := reconcilers.RetrieveOriginalResourceType(ctx).(*corev1.ConfigMap); !ok {
+								t.Errorf("expected original resource type not in context, found %#v", resourceType)
+							}
+							if resourceType, ok := reconcilers.RetrieveResourceType(ctx).(*corev1.ConfigMap); !ok {
+								t.Errorf("expected resource type not in context, found %#v", resourceType)
+							}
+							return nil
+						},
+					}
+					return r
+				},
 			},
 		},
-		ExpectEvents: []rtesting.Event{
-			rtesting.NewEvent(configMapGiven, scheme, corev1.EventTypeWarning, "UpdateFailed",
-				`Failed to update ConfigMap %q: inducing failure for update ConfigMap`, testName),
-		},
-		ExpectUpdates: []client.Object{
-			configMapGiven.
-				AddData("foo", "bar"),
-		},
-		ShouldErr: true,
-	}, {
-		Name: "error deleting resource",
-		Key:  key,
-		GivenObjects: []client.Object{
-			configMapGiven,
-		},
-		WithReactors: []rtesting.ReactionFunc{
-			rtesting.InduceFailure("delete", "ConfigMap"),
-		},
-		Metadata: map[string]interface{}{
-			"Reconciler": func(t *testing.T, c reconcilers.Config) reconcile.Reconciler {
-				r := defaultAggregateReconciler(c)
-				r.DesiredResource = func(ctx context.Context, resource client.Object) (client.Object, error) {
-					return nil, nil
-				}
-				return r
-			},
-		},
-		ExpectEvents: []rtesting.Event{
-			rtesting.NewEvent(configMapGiven, scheme, corev1.EventTypeWarning, "DeleteFailed",
-				`Failed to delete ConfigMap %q: inducing failure for delete ConfigMap`, testName),
-		},
-		ExpectDeletes: []rtesting.DeleteRef{
-			rtesting.NewDeleteRefFromObject(configMapGiven, scheme),
-		},
-		ShouldErr: true,
-	}, {
-		Name: "reconcile result",
-		Key:  key,
-		GivenObjects: []client.Object{
-			configMapGiven.
-				AddData("foo", "bar"),
-		},
-		Metadata: map[string]interface{}{
-			"Reconciler": func(t *testing.T, c reconcilers.Config) reconcile.Reconciler {
-				r := defaultAggregateReconciler(c)
-				r.Reconciler = &reconcilers.SyncReconciler{
-					Sync: func(ctx context.Context, resource client.Object) (ctrl.Result, error) {
-						return ctrl.Result{RequeueAfter: time.Hour}, nil
-					},
-				}
-				return r
-			},
-		},
-		ExpectedResult: ctrl.Result{RequeueAfter: time.Hour},
-	}, {
-		Name: "reconcile error",
-		Key:  key,
-		Metadata: map[string]interface{}{
-			"Reconciler": func(t *testing.T, c reconcilers.Config) reconcile.Reconciler {
-				r := defaultAggregateReconciler(c)
-				r.Reconciler = &reconcilers.SyncReconciler{
-					Sync: func(ctx context.Context, resource client.Object) error {
-						return fmt.Errorf("test error")
-					},
-				}
-				return r
-			},
-		},
-		ShouldErr: true,
-	}, {
-		Name: "context is stashable",
-		Key:  key,
-		GivenObjects: []client.Object{
-			configMapGiven.
-				AddData("foo", "bar"),
-		},
-		Metadata: map[string]interface{}{
-			"Reconciler": func(t *testing.T, c reconcilers.Config) reconcile.Reconciler {
-				r := defaultAggregateReconciler(c)
-				r.Reconciler = &reconcilers.SyncReconciler{
-					Sync: func(ctx context.Context, resource *corev1.ConfigMap) error {
-						var key reconcilers.StashKey = "foo"
-						// StashValue will panic if the context is not setup correctly
-						reconcilers.StashValue(ctx, key, "bar")
-						return nil
-					},
-				}
-				return r
-			},
-		},
-	}, {
-		Name: "context has config",
-		Key:  key,
-		GivenObjects: []client.Object{
-			configMapGiven.
-				AddData("foo", "bar"),
-		},
-		Metadata: map[string]interface{}{
-			"Reconciler": func(t *testing.T, c reconcilers.Config) reconcile.Reconciler {
-				r := defaultAggregateReconciler(c)
-				r.Reconciler = &reconcilers.SyncReconciler{
-					Sync: func(ctx context.Context, resource *corev1.ConfigMap) error {
-						if config := reconcilers.RetrieveConfigOrDie(ctx); config != c {
-							t.Errorf("expected config in context, found %#v", config)
-						}
-						if resourceConfig := reconcilers.RetrieveOriginalConfigOrDie(ctx); resourceConfig != c {
-							t.Errorf("expected original config in context, found %#v", resourceConfig)
-						}
-						return nil
-					},
-				}
-				return r
-			},
-		},
-	}, {
-		Name: "context has resource type",
-		Key:  key,
-		GivenObjects: []client.Object{
-			configMapGiven.
-				AddData("foo", "bar"),
-		},
-		Metadata: map[string]interface{}{
-			"Reconciler": func(t *testing.T, c reconcilers.Config) reconcile.Reconciler {
-				r := defaultAggregateReconciler(c)
-				r.Reconciler = &reconcilers.SyncReconciler{
-					Sync: func(ctx context.Context, resource *corev1.ConfigMap) error {
-						if resourceType, ok := reconcilers.RetrieveOriginalResourceType(ctx).(*corev1.ConfigMap); !ok {
-							t.Errorf("expected original resource type not in context, found %#v", resourceType)
-						}
-						if resourceType, ok := reconcilers.RetrieveResourceType(ctx).(*corev1.ConfigMap); !ok {
-							t.Errorf("expected resource type not in context, found %#v", resourceType)
-						}
-						return nil
-					},
-				}
-				return r
-			},
-		},
-	}}
+	}
 
 	rts.Run(t, scheme, func(t *testing.T, rtc *rtesting.ReconcilerTestCase, c reconcilers.Config) reconcile.Reconciler {
 		return rtc.Metadata["Reconciler"].(func(*testing.T, reconcilers.Config) reconcile.Reconciler)(t, c)
@@ -1020,167 +1026,168 @@ func TestSyncReconciler(t *testing.T) {
 			)
 		})
 
-	rts := rtesting.SubReconcilerTestSuite{{
-		Name:     "sync success",
-		Resource: resource,
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return &reconcilers.SyncReconciler{
-					Sync: func(ctx context.Context, resource *resources.TestResource) error {
-						return nil
-					},
-				}
+	rts := rtesting.SubReconcilerTests{
+		"sync success": {
+			Resource: resource,
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return &reconcilers.SyncReconciler{
+						Sync: func(ctx context.Context, resource *resources.TestResource) error {
+							return nil
+						},
+					}
+				},
 			},
 		},
-	}, {
-		Name:     "sync error",
-		Resource: resource,
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return &reconcilers.SyncReconciler{
-					Sync: func(ctx context.Context, resource *resources.TestResource) error {
-						return fmt.Errorf("syncreconciler error")
-					},
-				}
+		"sync error": {
+			Resource: resource,
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return &reconcilers.SyncReconciler{
+						Sync: func(ctx context.Context, resource *resources.TestResource) error {
+							return fmt.Errorf("syncreconciler error")
+						},
+					}
+				},
+			},
+			ShouldErr: true,
+		},
+		"missing sync method": {
+			Resource: resource,
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return &reconcilers.SyncReconciler{
+						Sync: nil,
+					}
+				},
+			},
+			ShouldPanic: true,
+		},
+		"invalid sync signature": {
+			Resource: resource,
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return &reconcilers.SyncReconciler{
+						Sync: func(ctx context.Context, resource string) error {
+							return nil
+						},
+					}
+				},
+			},
+			ShouldPanic: true,
+		},
+		"should not finalize non-deleted resources": {
+			Resource: resource,
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return &reconcilers.SyncReconciler{
+						Sync: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
+							return ctrl.Result{RequeueAfter: 2 * time.Hour}, nil
+						},
+						Finalize: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
+							t.Errorf("reconciler should not call finalize for non-deleted resources")
+							return ctrl.Result{RequeueAfter: 3 * time.Hour}, nil
+						},
+					}
+				},
+			},
+			ExpectedResult: reconcile.Result{RequeueAfter: 2 * time.Hour},
+		},
+		"should finalize deleted resources": {
+			Resource: resource.
+				MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+					d.DeletionTimestamp(&now)
+				}),
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return &reconcilers.SyncReconciler{
+						Sync: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
+							t.Errorf("reconciler should not call sync for deleted resources")
+							return ctrl.Result{RequeueAfter: 2 * time.Hour}, nil
+						},
+						Finalize: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
+							return ctrl.Result{RequeueAfter: 3 * time.Hour}, nil
+						},
+					}
+				},
+			},
+			ExpectedResult: reconcile.Result{RequeueAfter: 3 * time.Hour},
+		},
+		"should finalize and sync deleted resources when asked to": {
+			Resource: resource.
+				MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+					d.DeletionTimestamp(&now)
+				}),
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return &reconcilers.SyncReconciler{
+						SyncDuringFinalization: true,
+						Sync: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
+							return ctrl.Result{RequeueAfter: 2 * time.Hour}, nil
+						},
+						Finalize: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
+							return ctrl.Result{RequeueAfter: 3 * time.Hour}, nil
+						},
+					}
+				},
+			},
+			ExpectedResult: reconcile.Result{RequeueAfter: 2 * time.Hour},
+		},
+		"should finalize and sync deleted resources when asked to, shorter resync wins": {
+			Resource: resource.
+				MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+					d.DeletionTimestamp(&now)
+				}),
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return &reconcilers.SyncReconciler{
+						SyncDuringFinalization: true,
+						Sync: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
+							return ctrl.Result{RequeueAfter: 3 * time.Hour}, nil
+						},
+						Finalize: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
+							return ctrl.Result{RequeueAfter: 2 * time.Hour}, nil
+						},
+					}
+				},
+			},
+			ExpectedResult: reconcile.Result{RequeueAfter: 2 * time.Hour},
+		},
+		"finalize is optional": {
+			Resource: resource.
+				MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+					d.DeletionTimestamp(&now)
+				}),
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return &reconcilers.SyncReconciler{
+						Sync: func(ctx context.Context, resource *resources.TestResource) error {
+							return nil
+						},
+					}
+				},
 			},
 		},
-		ShouldErr: true,
-	}, {
-		Name:     "missing sync method",
-		Resource: resource,
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return &reconcilers.SyncReconciler{
-					Sync: nil,
-				}
+		"finalize error": {
+			Resource: resource.
+				MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+					d.DeletionTimestamp(&now)
+				}),
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return &reconcilers.SyncReconciler{
+						Sync: func(ctx context.Context, resource *resources.TestResource) error {
+							return nil
+						},
+						Finalize: func(ctx context.Context, resource *resources.TestResource) error {
+							return fmt.Errorf("syncreconciler finalize error")
+						},
+					}
+				},
 			},
+			ShouldErr: true,
 		},
-		ShouldPanic: true,
-	}, {
-		Name:     "invalid sync signature",
-		Resource: resource,
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return &reconcilers.SyncReconciler{
-					Sync: func(ctx context.Context, resource string) error {
-						return nil
-					},
-				}
-			},
-		},
-		ShouldPanic: true,
-	}, {
-		Name:     "should not finalize non-deleted resources",
-		Resource: resource,
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return &reconcilers.SyncReconciler{
-					Sync: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
-						return ctrl.Result{RequeueAfter: 2 * time.Hour}, nil
-					},
-					Finalize: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
-						t.Errorf("reconciler should not call finalize for non-deleted resources")
-						return ctrl.Result{RequeueAfter: 3 * time.Hour}, nil
-					},
-				}
-			},
-		},
-		ExpectedResult: reconcile.Result{RequeueAfter: 2 * time.Hour},
-	}, {
-		Name: "should finalize deleted resources",
-		Resource: resource.
-			MetadataDie(func(d *diemetav1.ObjectMetaDie) {
-				d.DeletionTimestamp(&now)
-			}),
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return &reconcilers.SyncReconciler{
-					Sync: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
-						t.Errorf("reconciler should not call sync for deleted resources")
-						return ctrl.Result{RequeueAfter: 2 * time.Hour}, nil
-					},
-					Finalize: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
-						return ctrl.Result{RequeueAfter: 3 * time.Hour}, nil
-					},
-				}
-			},
-		},
-		ExpectedResult: reconcile.Result{RequeueAfter: 3 * time.Hour},
-	}, {
-		Name: "should finalize and sync deleted resources when asked to",
-		Resource: resource.
-			MetadataDie(func(d *diemetav1.ObjectMetaDie) {
-				d.DeletionTimestamp(&now)
-			}),
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return &reconcilers.SyncReconciler{
-					SyncDuringFinalization: true,
-					Sync: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
-						return ctrl.Result{RequeueAfter: 2 * time.Hour}, nil
-					},
-					Finalize: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
-						return ctrl.Result{RequeueAfter: 3 * time.Hour}, nil
-					},
-				}
-			},
-		},
-		ExpectedResult: reconcile.Result{RequeueAfter: 2 * time.Hour},
-	}, {
-		Name: "should finalize and sync deleted resources when asked to, shorter resync wins",
-		Resource: resource.
-			MetadataDie(func(d *diemetav1.ObjectMetaDie) {
-				d.DeletionTimestamp(&now)
-			}),
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return &reconcilers.SyncReconciler{
-					SyncDuringFinalization: true,
-					Sync: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
-						return ctrl.Result{RequeueAfter: 3 * time.Hour}, nil
-					},
-					Finalize: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
-						return ctrl.Result{RequeueAfter: 2 * time.Hour}, nil
-					},
-				}
-			},
-		},
-		ExpectedResult: reconcile.Result{RequeueAfter: 2 * time.Hour},
-	}, {
-		Name: "finalize is optional",
-		Resource: resource.
-			MetadataDie(func(d *diemetav1.ObjectMetaDie) {
-				d.DeletionTimestamp(&now)
-			}),
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return &reconcilers.SyncReconciler{
-					Sync: func(ctx context.Context, resource *resources.TestResource) error {
-						return nil
-					},
-				}
-			},
-		},
-	}, {
-		Name: "finalize error",
-		Resource: resource.
-			MetadataDie(func(d *diemetav1.ObjectMetaDie) {
-				d.DeletionTimestamp(&now)
-			}),
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return &reconcilers.SyncReconciler{
-					Sync: func(ctx context.Context, resource *resources.TestResource) error {
-						return nil
-					},
-					Finalize: func(ctx context.Context, resource *resources.TestResource) error {
-						return fmt.Errorf("syncreconciler finalize error")
-					},
-				}
-			},
-		},
-		ShouldErr: true,
-	}}
+	}
 
 	rts.Run(t, scheme, func(t *testing.T, rtc *rtesting.SubReconcilerTestCase, c reconcilers.Config) reconcilers.SubReconciler {
 		return rtc.Metadata["SubReconciler"].(func(*testing.T, reconcilers.Config) reconcilers.SubReconciler)(t, c)
@@ -1271,852 +1278,853 @@ func TestChildReconciler(t *testing.T) {
 		}
 	}
 
-	rts := rtesting.SubReconcilerTestSuite{{
-		Name:     "preserve no child",
-		Resource: resourceReady,
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return defaultChildReconciler(c)
+	rts := rtesting.SubReconcilerTests{
+		"preserve no child": {
+			Resource: resourceReady,
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return defaultChildReconciler(c)
+				},
 			},
 		},
-	}, {
-		Name: "child is in sync",
-		Resource: resourceReady.
-			SpecDie(func(d *dies.TestResourceSpecDie) {
-				d.AddField("foo", "bar")
-			}).
-			StatusDie(func(d *dies.TestResourceStatusDie) {
-				d.AddField("foo", "bar")
-			}),
-		GivenObjects: []client.Object{
-			configMapGiven,
-		},
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return defaultChildReconciler(c)
-			},
-		},
-	}, {
-		Name: "child is in sync, in a different namespace",
-		Resource: resourceReady.
-			SpecDie(func(d *dies.TestResourceSpecDie) {
-				d.AddField("foo", "bar")
-			}).
-			StatusDie(func(d *dies.TestResourceStatusDie) {
-				d.AddField("foo", "bar")
-			}),
-		GivenObjects: []client.Object{
-			configMapGiven.
-				MetadataDie(func(d *diemetav1.ObjectMetaDie) {
-					d.Namespace("other-ns")
+		"child is in sync": {
+			Resource: resourceReady.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
+				}).
+				StatusDie(func(d *dies.TestResourceStatusDie) {
+					d.AddField("foo", "bar")
 				}),
+			GivenObjects: []client.Object{
+				configMapGiven,
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return defaultChildReconciler(c)
+				},
+			},
 		},
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				r := defaultChildReconciler(c)
-				r.ListOptions = func(ctx context.Context, parent *resources.TestResource) []client.ListOption {
-					return []client.ListOption{
-						client.InNamespace("other-ns"),
+		"child is in sync, in a different namespace": {
+			Resource: resourceReady.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
+				}).
+				StatusDie(func(d *dies.TestResourceStatusDie) {
+					d.AddField("foo", "bar")
+				}),
+			GivenObjects: []client.Object{
+				configMapGiven.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.Namespace("other-ns")
+					}),
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					r := defaultChildReconciler(c)
+					r.ListOptions = func(ctx context.Context, parent *resources.TestResource) []client.ListOption {
+						return []client.ListOption{
+							client.InNamespace("other-ns"),
+						}
 					}
-				}
-				return r
+					return r
+				},
 			},
 		},
-	}, {
-		Name: "create child",
-		Resource: resource.
-			SpecDie(func(d *dies.TestResourceSpecDie) {
-				d.AddField("foo", "bar")
-			}),
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return defaultChildReconciler(c)
-			},
-		},
-		ExpectEvents: []rtesting.Event{
-			rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Created",
-				`Created ConfigMap %q`, testName),
-		},
-		ExpectResource: resourceReady.
-			SpecDie(func(d *dies.TestResourceSpecDie) {
-				d.AddField("foo", "bar")
-			}).
-			StatusDie(func(d *dies.TestResourceStatusDie) {
-				d.AddField("foo", "bar")
-			}),
-		ExpectCreates: []client.Object{
-			configMapCreate,
-		},
-	}, {
-		Name: "create child with finalizer",
-		Resource: resource.
-			SpecDie(func(d *dies.TestResourceSpecDie) {
-				d.AddField("foo", "bar")
-			}),
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				r := defaultChildReconciler(c)
-				r.Finalizer = testFinalizer
-				r.SkipOwnerReference = true
-				r.OurChild = func(parent, child client.Object) bool { return true }
-				return r
-			},
-		},
-		ExpectTracks: []rtesting.TrackRequest{
-			rtesting.NewTrackRequest(configMapCreate, resource, scheme),
-		},
-		ExpectEvents: []rtesting.Event{
-			rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "FinalizerPatched",
-				`Patched finalizer %q`, testFinalizer),
-			rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Created",
-				`Created ConfigMap %q`, testName),
-		},
-		ExpectResource: resourceReady.
-			MetadataDie(func(d *diemetav1.ObjectMetaDie) {
-				d.Finalizers(testFinalizer)
-				d.ResourceVersion("1000")
-			}).
-			SpecDie(func(d *dies.TestResourceSpecDie) {
-				d.AddField("foo", "bar")
-			}).
-			StatusDie(func(d *dies.TestResourceStatusDie) {
-				d.AddField("foo", "bar")
-			}),
-		ExpectCreates: []client.Object{
-			configMapCreate.
-				MetadataDie(func(d *diemetav1.ObjectMetaDie) {
-					d.OwnerReferences()
+		"create child": {
+			Resource: resource.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
 				}),
-		},
-		ExpectPatches: []rtesting.PatchRef{
-			{
-				Group:     "testing.reconciler.runtime",
-				Kind:      "TestResource",
-				Namespace: testNamespace,
-				Name:      testName,
-				PatchType: types.MergePatchType,
-				Patch:     []byte(`{"metadata":{"finalizers":["test.finalizer"],"resourceVersion":"999"}}`),
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return defaultChildReconciler(c)
+				},
 			},
-		},
-	}, {
-		Name: "update child",
-		Resource: resourceReady.
-			SpecDie(func(d *dies.TestResourceSpecDie) {
-				d.AddField("foo", "bar")
-				d.AddField("new", "field")
-			}).
-			StatusDie(func(d *dies.TestResourceStatusDie) {
-				d.AddField("foo", "bar")
-			}),
-		GivenObjects: []client.Object{
-			configMapGiven,
-		},
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return defaultChildReconciler(c)
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Created",
+					`Created ConfigMap %q`, testName),
 			},
-		},
-		ExpectEvents: []rtesting.Event{
-			rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Updated",
-				`Updated ConfigMap %q`, testName),
-		},
-		ExpectResource: resourceReady.
-			SpecDie(func(d *dies.TestResourceSpecDie) {
-				d.AddField("foo", "bar")
-				d.AddField("new", "field")
-			}).
-			StatusDie(func(d *dies.TestResourceStatusDie) {
-				d.AddField("foo", "bar")
-				d.AddField("new", "field")
-			}),
-		ExpectUpdates: []client.Object{
-			configMapGiven.
-				AddData("new", "field"),
-		},
-	}, {
-		Name: "update child, preserve finalizers",
-		Resource: resourceReady.
-			MetadataDie(func(d *diemetav1.ObjectMetaDie) {
-				d.Finalizers(testFinalizer, "some.other.finalizer")
-			}).
-			SpecDie(func(d *dies.TestResourceSpecDie) {
-				d.AddField("foo", "bar")
-				d.AddField("new", "field")
-			}).
-			StatusDie(func(d *dies.TestResourceStatusDie) {
-				d.AddField("foo", "bar")
-			}),
-		GivenObjects: []client.Object{
-			configMapGiven.
-				MetadataDie(func(d *diemetav1.ObjectMetaDie) {
-					d.OwnerReferences()
-				}),
-		},
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				r := defaultChildReconciler(c)
-				r.Finalizer = testFinalizer
-				r.SkipOwnerReference = true
-				r.OurChild = func(parent, child client.Object) bool { return true }
-				return r
-			},
-		},
-		ExpectTracks: []rtesting.TrackRequest{
-			rtesting.NewTrackRequest(configMapGiven, resource, scheme),
-		},
-		ExpectEvents: []rtesting.Event{
-			rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Updated",
-				`Updated ConfigMap %q`, testName),
-		},
-		ExpectResource: resourceReady.
-			MetadataDie(func(d *diemetav1.ObjectMetaDie) {
-				d.Finalizers(testFinalizer, "some.other.finalizer")
-			}).
-			SpecDie(func(d *dies.TestResourceSpecDie) {
-				d.AddField("foo", "bar")
-				d.AddField("new", "field")
-			}).
-			StatusDie(func(d *dies.TestResourceStatusDie) {
-				d.AddField("foo", "bar")
-				d.AddField("new", "field")
-			}),
-		ExpectUpdates: []client.Object{
-			configMapGiven.
-				MetadataDie(func(d *diemetav1.ObjectMetaDie) {
-					d.OwnerReferences()
+			ExpectResource: resourceReady.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
 				}).
-				AddData("new", "field"),
-		},
-	}, {
-		Name: "update child, restoring missing finalizer",
-		Resource: resourceReady.
-			SpecDie(func(d *dies.TestResourceSpecDie) {
-				d.AddField("foo", "bar")
-				d.AddField("new", "field")
-			}).
-			StatusDie(func(d *dies.TestResourceStatusDie) {
-				d.AddField("foo", "bar")
-			}),
-		GivenObjects: []client.Object{
-			configMapGiven.
-				MetadataDie(func(d *diemetav1.ObjectMetaDie) {
-					d.OwnerReferences()
+				StatusDie(func(d *dies.TestResourceStatusDie) {
+					d.AddField("foo", "bar")
 				}),
-		},
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				r := defaultChildReconciler(c)
-				r.Finalizer = testFinalizer
-				r.SkipOwnerReference = true
-				r.OurChild = func(parent, child client.Object) bool { return true }
-				return r
+			ExpectCreates: []client.Object{
+				configMapCreate,
 			},
 		},
-		ExpectTracks: []rtesting.TrackRequest{
-			rtesting.NewTrackRequest(configMapGiven, resource, scheme),
-		},
-		ExpectEvents: []rtesting.Event{
-			rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "FinalizerPatched",
-				`Patched finalizer %q`, testFinalizer),
-			rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Updated",
-				`Updated ConfigMap %q`, testName),
-		},
-		ExpectResource: resourceReady.
-			MetadataDie(func(d *diemetav1.ObjectMetaDie) {
-				d.Finalizers(testFinalizer)
-				d.ResourceVersion("1000")
-			}).
-			SpecDie(func(d *dies.TestResourceSpecDie) {
-				d.AddField("foo", "bar")
-				d.AddField("new", "field")
-			}).
-			StatusDie(func(d *dies.TestResourceStatusDie) {
-				d.AddField("foo", "bar")
-				d.AddField("new", "field")
-			}),
-		ExpectUpdates: []client.Object{
-			configMapGiven.
+		"create child with finalizer": {
+			Resource: resource.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
+				}),
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					r := defaultChildReconciler(c)
+					r.Finalizer = testFinalizer
+					r.SkipOwnerReference = true
+					r.OurChild = func(parent, child client.Object) bool { return true }
+					return r
+				},
+			},
+			ExpectTracks: []rtesting.TrackRequest{
+				rtesting.NewTrackRequest(configMapCreate, resource, scheme),
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "FinalizerPatched",
+					`Patched finalizer %q`, testFinalizer),
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Created",
+					`Created ConfigMap %q`, testName),
+			},
+			ExpectResource: resourceReady.
 				MetadataDie(func(d *diemetav1.ObjectMetaDie) {
-					d.OwnerReferences()
+					d.Finalizers(testFinalizer)
+					d.ResourceVersion("1000")
 				}).
-				AddData("new", "field"),
-		},
-		ExpectPatches: []rtesting.PatchRef{
-			{
-				Group:     "testing.reconciler.runtime",
-				Kind:      "TestResource",
-				Namespace: testNamespace,
-				Name:      testName,
-				PatchType: types.MergePatchType,
-				Patch:     []byte(`{"metadata":{"finalizers":["test.finalizer"],"resourceVersion":"999"}}`),
-			},
-		},
-	}, {
-		Name:     "delete child",
-		Resource: resourceReady,
-		GivenObjects: []client.Object{
-			configMapGiven,
-		},
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return defaultChildReconciler(c)
-			},
-		},
-		ExpectEvents: []rtesting.Event{
-			rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Deleted",
-				`Deleted ConfigMap %q`, testName),
-		},
-		ExpectDeletes: []rtesting.DeleteRef{
-			rtesting.NewDeleteRefFromObject(configMapGiven, scheme),
-		},
-	}, {
-		Name: "delete child, clearing finalizer",
-		Resource: resourceReady.
-			MetadataDie(func(d *diemetav1.ObjectMetaDie) {
-				d.Finalizers(testFinalizer)
-			}),
-		GivenObjects: []client.Object{
-			configMapGiven.
-				MetadataDie(func(d *diemetav1.ObjectMetaDie) {
-					d.OwnerReferences()
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
+				}).
+				StatusDie(func(d *dies.TestResourceStatusDie) {
+					d.AddField("foo", "bar")
 				}),
-		},
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				r := defaultChildReconciler(c)
-				r.Finalizer = testFinalizer
-				r.SkipOwnerReference = true
-				r.OurChild = func(parent, child client.Object) bool { return true }
-				return r
+			ExpectCreates: []client.Object{
+				configMapCreate.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.OwnerReferences()
+					}),
+			},
+			ExpectPatches: []rtesting.PatchRef{
+				{
+					Group:     "testing.reconciler.runtime",
+					Kind:      "TestResource",
+					Namespace: testNamespace,
+					Name:      testName,
+					PatchType: types.MergePatchType,
+					Patch:     []byte(`{"metadata":{"finalizers":["test.finalizer"],"resourceVersion":"999"}}`),
+				},
 			},
 		},
-		ExpectEvents: []rtesting.Event{
-			rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Deleted",
-				`Deleted ConfigMap %q`, testName),
-			rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "FinalizerPatched",
-				`Patched finalizer %q`, testFinalizer),
-		},
-		ExpectResource: resourceReady.
-			MetadataDie(func(d *diemetav1.ObjectMetaDie) {
-				d.Finalizers()
-				d.ResourceVersion("1000")
-			}),
-		ExpectDeletes: []rtesting.DeleteRef{
-			rtesting.NewDeleteRefFromObject(configMapGiven, scheme),
-		},
-		ExpectPatches: []rtesting.PatchRef{
-			{
-				Group:     "testing.reconciler.runtime",
-				Kind:      "TestResource",
-				Namespace: testNamespace,
-				Name:      testName,
-				PatchType: types.MergePatchType,
-				Patch:     []byte(`{"metadata":{"finalizers":null,"resourceVersion":"999"}}`),
-			},
-		},
-	}, {
-		Name: "delete child, preserve other finalizer",
-		Resource: resourceReady.
-			MetadataDie(func(d *diemetav1.ObjectMetaDie) {
-				d.Finalizers("some.other.finalizer")
-			}),
-		GivenObjects: []client.Object{
-			configMapGiven.
-				MetadataDie(func(d *diemetav1.ObjectMetaDie) {
-					d.OwnerReferences()
+		"update child": {
+			Resource: resourceReady.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
+					d.AddField("new", "field")
+				}).
+				StatusDie(func(d *dies.TestResourceStatusDie) {
+					d.AddField("foo", "bar")
 				}),
-		},
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				r := defaultChildReconciler(c)
-				r.Finalizer = testFinalizer
-				r.SkipOwnerReference = true
-				r.OurChild = func(parent, child client.Object) bool { return true }
-				return r
+			GivenObjects: []client.Object{
+				configMapGiven,
 			},
-		},
-		ExpectEvents: []rtesting.Event{
-			rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Deleted",
-				`Deleted ConfigMap %q`, testName),
-		},
-		ExpectDeletes: []rtesting.DeleteRef{
-			rtesting.NewDeleteRefFromObject(configMapGiven, scheme),
-		},
-	}, {
-		Name:     "ignore extraneous children",
-		Resource: resourceReady,
-		GivenObjects: []client.Object{
-			configMapGiven,
-		},
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				r := defaultChildReconciler(c)
-				r.OurChild = func(parent *resources.TestResource, child *corev1.ConfigMap) bool {
-					return false
-				}
-				return r
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return defaultChildReconciler(c)
+				},
 			},
-		},
-	}, {
-		Name: "delete duplicate children",
-		Resource: resource.
-			SpecDie(func(d *dies.TestResourceSpecDie) {
-				d.AddField("foo", "bar")
-			}),
-		GivenObjects: []client.Object{
-			configMapGiven.
-				MetadataDie(func(d *diemetav1.ObjectMetaDie) {
-					d.Name("extra-child-1")
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Updated",
+					`Updated ConfigMap %q`, testName),
+			},
+			ExpectResource: resourceReady.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
+					d.AddField("new", "field")
+				}).
+				StatusDie(func(d *dies.TestResourceStatusDie) {
+					d.AddField("foo", "bar")
+					d.AddField("new", "field")
 				}),
-			configMapGiven.
+			ExpectUpdates: []client.Object{
+				configMapGiven.
+					AddData("new", "field"),
+			},
+		},
+		"update child, preserve finalizers": {
+			Resource: resourceReady.
 				MetadataDie(func(d *diemetav1.ObjectMetaDie) {
-					d.Name("extra-child-2")
+					d.Finalizers(testFinalizer, "some.other.finalizer")
+				}).
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
+					d.AddField("new", "field")
+				}).
+				StatusDie(func(d *dies.TestResourceStatusDie) {
+					d.AddField("foo", "bar")
 				}),
-		},
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return defaultChildReconciler(c)
+			GivenObjects: []client.Object{
+				configMapGiven.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.OwnerReferences()
+					}),
 			},
-		},
-		ExpectResource: resourceReady.
-			SpecDie(func(d *dies.TestResourceSpecDie) {
-				d.AddField("foo", "bar")
-			}).
-			StatusDie(func(d *dies.TestResourceStatusDie) {
-				d.AddField("foo", "bar")
-			}),
-		ExpectEvents: []rtesting.Event{
-			rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Deleted",
-				`Deleted ConfigMap %q`, "extra-child-1"),
-			rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Deleted",
-				`Deleted ConfigMap %q`, "extra-child-2"),
-			rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Created",
-				`Created ConfigMap %q`, testName),
-		},
-		ExpectDeletes: []rtesting.DeleteRef{
-			{Group: "", Kind: "ConfigMap", Namespace: testNamespace, Name: "extra-child-1"},
-			{Group: "", Kind: "ConfigMap", Namespace: testNamespace, Name: "extra-child-2"},
-		},
-		ExpectCreates: []client.Object{
-			configMapCreate,
-		},
-	}, {
-		Name: "delete child durring finalization",
-		Resource: resourceReady.
-			MetadataDie(func(d *diemetav1.ObjectMetaDie) {
-				d.DeletionTimestamp(&now)
-				d.Finalizers(testFinalizer)
-			}),
-		GivenObjects: []client.Object{
-			configMapGiven.
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					r := defaultChildReconciler(c)
+					r.Finalizer = testFinalizer
+					r.SkipOwnerReference = true
+					r.OurChild = func(parent, child client.Object) bool { return true }
+					return r
+				},
+			},
+			ExpectTracks: []rtesting.TrackRequest{
+				rtesting.NewTrackRequest(configMapGiven, resource, scheme),
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Updated",
+					`Updated ConfigMap %q`, testName),
+			},
+			ExpectResource: resourceReady.
 				MetadataDie(func(d *diemetav1.ObjectMetaDie) {
-					d.OwnerReferences()
+					d.Finalizers(testFinalizer, "some.other.finalizer")
+				}).
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
+					d.AddField("new", "field")
+				}).
+				StatusDie(func(d *dies.TestResourceStatusDie) {
+					d.AddField("foo", "bar")
+					d.AddField("new", "field")
 				}),
-		},
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				r := defaultChildReconciler(c)
-				r.Finalizer = testFinalizer
-				r.SkipOwnerReference = true
-				r.OurChild = func(parent, child client.Object) bool { return true }
-				return r
+			ExpectUpdates: []client.Object{
+				configMapGiven.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.OwnerReferences()
+					}).
+					AddData("new", "field"),
 			},
 		},
-		ExpectEvents: []rtesting.Event{
-			rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Deleted",
-				`Deleted ConfigMap %q`, testName),
-			rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "FinalizerPatched",
-				`Patched finalizer %q`, testFinalizer),
-		},
-		ExpectResource: resourceReady.
-			MetadataDie(func(d *diemetav1.ObjectMetaDie) {
-				d.DeletionTimestamp(&now)
-				d.Finalizers()
-				d.ResourceVersion("1000")
-			}),
-		ExpectDeletes: []rtesting.DeleteRef{
-			rtesting.NewDeleteRefFromObject(configMapGiven, scheme),
-		},
-		ExpectPatches: []rtesting.PatchRef{
-			{
-				Group:     "testing.reconciler.runtime",
-				Kind:      "TestResource",
-				Namespace: testNamespace,
-				Name:      testName,
-				PatchType: types.MergePatchType,
-				Patch:     []byte(`{"metadata":{"finalizers":null,"resourceVersion":"999"}}`),
+		"update child, restoring missing finalizer": {
+			Resource: resourceReady.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
+					d.AddField("new", "field")
+				}).
+				StatusDie(func(d *dies.TestResourceStatusDie) {
+					d.AddField("foo", "bar")
+				}),
+			GivenObjects: []client.Object{
+				configMapGiven.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.OwnerReferences()
+					}),
 			},
-		},
-	}, {
-		Name: "child name collision",
-		Resource: resourceReady.
-			SpecDie(func(d *dies.TestResourceSpecDie) {
-				d.AddField("foo", "bar")
-			}),
-		WithReactors: []rtesting.ReactionFunc{
-			rtesting.InduceFailure("create", "ConfigMap", rtesting.InduceFailureOpts{
-				Error: apierrs.NewAlreadyExists(schema.GroupResource{}, testName),
-			}),
-		},
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return defaultChildReconciler(c)
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					r := defaultChildReconciler(c)
+					r.Finalizer = testFinalizer
+					r.SkipOwnerReference = true
+					r.OurChild = func(parent, child client.Object) bool { return true }
+					return r
+				},
 			},
-		},
-		ExpectResource: resourceReady.
-			SpecDie(func(d *dies.TestResourceSpecDie) {
-				d.AddField("foo", "bar")
-			}).
-			StatusDie(func(d *dies.TestResourceStatusDie) {
-				d.ConditionsDie(
-					diemetav1.ConditionBlank.Type(apis.ConditionReady).Status(metav1.ConditionFalse).
-						Reason("NameConflict").Message(`"test-resource" already exists`),
-				)
-			}),
-		ExpectEvents: []rtesting.Event{
-			rtesting.NewEvent(resource, scheme, corev1.EventTypeWarning, "CreationFailed",
-				"Failed to create ConfigMap %q:  %q already exists", testName, testName),
-		},
-		ExpectCreates: []client.Object{
-			configMapCreate,
-		},
-	}, {
-		Name: "child name collision, stale informer cache",
-		Resource: resourceReady.
-			SpecDie(func(d *dies.TestResourceSpecDie) {
-				d.AddField("foo", "bar")
-			}),
-		APIGivenObjects: []client.Object{
-			configMapGiven,
-		},
-		WithReactors: []rtesting.ReactionFunc{
-			rtesting.InduceFailure("create", "ConfigMap", rtesting.InduceFailureOpts{
-				Error: apierrs.NewAlreadyExists(schema.GroupResource{}, testName),
-			}),
-		},
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return defaultChildReconciler(c)
+			ExpectTracks: []rtesting.TrackRequest{
+				rtesting.NewTrackRequest(configMapGiven, resource, scheme),
 			},
-		},
-		ExpectEvents: []rtesting.Event{
-			rtesting.NewEvent(resource, scheme, corev1.EventTypeWarning, "CreationFailed",
-				"Failed to create ConfigMap %q:  %q already exists", testName, testName),
-		},
-		ExpectCreates: []client.Object{
-			configMapCreate,
-		},
-		ShouldErr: true,
-	}, {
-		Name: "preserve immutable fields",
-		Resource: resourceReady.
-			SpecDie(func(d *dies.TestResourceSpecDie) {
-				d.AddField("foo", "bar")
-			}).
-			StatusDie(func(d *dies.TestResourceStatusDie) {
-				d.AddField("foo", "bar")
-				d.AddField("immutable", "field")
-			}),
-		GivenObjects: []client.Object{
-			configMapGiven.
-				AddData("immutable", "field"),
-		},
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				r := defaultChildReconciler(c)
-				r.HarmonizeImmutableFields = func(current, desired *corev1.ConfigMap) {
-					desired.Data["immutable"] = current.Data["immutable"]
-				}
-				return r
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "FinalizerPatched",
+					`Patched finalizer %q`, testFinalizer),
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Updated",
+					`Updated ConfigMap %q`, testName),
 			},
-		},
-	}, {
-		Name:     "status only reconcile",
-		Resource: resource,
-		GivenObjects: []client.Object{
-			configMapGiven,
-		},
-		ExpectResource: resourceReady.
-			StatusDie(func(d *dies.TestResourceStatusDie) {
-				d.AddField("foo", "bar")
-			}),
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				r := defaultChildReconciler(c)
-				r.DesiredChild = func(ctx context.Context, parent *resources.TestResource) (*corev1.ConfigMap, error) {
-					return nil, reconcilers.OnlyReconcileChildStatus
-				}
-				return r
-			},
-		},
-	}, {
-		Name: "sanitize child before logging",
-		Resource: resource.
-			SpecDie(func(d *dies.TestResourceSpecDie) {
-				d.AddField("foo", "bar")
-			}),
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				r := defaultChildReconciler(c)
-				r.Sanitize = func(child *corev1.ConfigMap) interface{} {
-					return child.Name
-				}
-				return r
-			},
-		},
-		ExpectEvents: []rtesting.Event{
-			rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Created",
-				`Created ConfigMap %q`, testName),
-		},
-		ExpectResource: resourceReady.
-			SpecDie(func(d *dies.TestResourceSpecDie) {
-				d.AddField("foo", "bar")
-			}).
-			StatusDie(func(d *dies.TestResourceStatusDie) {
-				d.AddField("foo", "bar")
-			}),
-		ExpectCreates: []client.Object{
-			configMapCreate,
-		},
-	}, {
-		Name: "sanitize is mutation safe",
-		Resource: resource.
-			SpecDie(func(d *dies.TestResourceSpecDie) {
-				d.AddField("foo", "bar")
-			}),
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				r := defaultChildReconciler(c)
-				r.Sanitize = func(child *corev1.ConfigMap) interface{} {
-					child.Data["ignore"] = "me"
-					return child
-				}
-				return r
-			},
-		},
-		ExpectEvents: []rtesting.Event{
-			rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Created",
-				`Created ConfigMap %q`, testName),
-		},
-		ExpectResource: resourceReady.
-			SpecDie(func(d *dies.TestResourceSpecDie) {
-				d.AddField("foo", "bar")
-			}).
-			StatusDie(func(d *dies.TestResourceStatusDie) {
-				d.AddField("foo", "bar")
-			}),
-		ExpectCreates: []client.Object{
-			configMapCreate,
-		},
-	}, {
-		Name:     "error listing children",
-		Resource: resourceReady,
-		WithReactors: []rtesting.ReactionFunc{
-			rtesting.InduceFailure("list", "ConfigMapList"),
-		},
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return defaultChildReconciler(c)
-			},
-		},
-		ShouldErr: true,
-	}, {
-		Name: "error creating child",
-		Resource: resource.
-			SpecDie(func(d *dies.TestResourceSpecDie) {
-				d.AddField("foo", "bar")
-			}),
-		WithReactors: []rtesting.ReactionFunc{
-			rtesting.InduceFailure("create", "ConfigMap"),
-		},
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return defaultChildReconciler(c)
-			},
-		},
-		ExpectEvents: []rtesting.Event{
-			rtesting.NewEvent(resource, scheme, corev1.EventTypeWarning, "CreationFailed",
-				`Failed to create ConfigMap %q: inducing failure for create ConfigMap`, testName),
-		},
-		ExpectCreates: []client.Object{
-			configMapCreate,
-		},
-		ShouldErr: true,
-	}, {
-		Name: "error adding finalizer",
-		Resource: resource.
-			SpecDie(func(d *dies.TestResourceSpecDie) {
-				d.AddField("foo", "bar")
-			}),
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				r := defaultChildReconciler(c)
-				r.Finalizer = testFinalizer
-				r.SkipOwnerReference = true
-				r.OurChild = func(parent, child client.Object) bool { return true }
-				return r
-			},
-		},
-		WithReactors: []rtesting.ReactionFunc{
-			rtesting.InduceFailure("patch", "TestResource"),
-		},
-		ExpectEvents: []rtesting.Event{
-			rtesting.NewEvent(resource, scheme, corev1.EventTypeWarning, "FinalizerPatchFailed",
-				`Failed to patch finalizer %q: inducing failure for patch TestResource`, testFinalizer),
-		},
-		ExpectPatches: []rtesting.PatchRef{
-			{
-				Group:     "testing.reconciler.runtime",
-				Kind:      "TestResource",
-				Namespace: testNamespace,
-				Name:      testName,
-				PatchType: types.MergePatchType,
-				Patch:     []byte(`{"metadata":{"finalizers":["test.finalizer"],"resourceVersion":"999"}}`),
-			},
-		},
-		ShouldErr: true,
-	}, {
-		Name: "error clearing finalizer",
-		Resource: resourceReady.
-			MetadataDie(func(d *diemetav1.ObjectMetaDie) {
-				d.Finalizers(testFinalizer)
-			}),
-		GivenObjects: []client.Object{
-			configMapGiven.
+			ExpectResource: resourceReady.
 				MetadataDie(func(d *diemetav1.ObjectMetaDie) {
-					d.OwnerReferences()
+					d.Finalizers(testFinalizer)
+					d.ResourceVersion("1000")
+				}).
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
+					d.AddField("new", "field")
+				}).
+				StatusDie(func(d *dies.TestResourceStatusDie) {
+					d.AddField("foo", "bar")
+					d.AddField("new", "field")
 				}),
-		},
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				r := defaultChildReconciler(c)
-				r.Finalizer = testFinalizer
-				r.SkipOwnerReference = true
-				r.OurChild = func(parent, child client.Object) bool { return true }
-				return r
+			ExpectUpdates: []client.Object{
+				configMapGiven.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.OwnerReferences()
+					}).
+					AddData("new", "field"),
+			},
+			ExpectPatches: []rtesting.PatchRef{
+				{
+					Group:     "testing.reconciler.runtime",
+					Kind:      "TestResource",
+					Namespace: testNamespace,
+					Name:      testName,
+					PatchType: types.MergePatchType,
+					Patch:     []byte(`{"metadata":{"finalizers":["test.finalizer"],"resourceVersion":"999"}}`),
+				},
 			},
 		},
-		WithReactors: []rtesting.ReactionFunc{
-			rtesting.InduceFailure("patch", "TestResource"),
-		},
-		ExpectEvents: []rtesting.Event{
-			rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Deleted",
-				`Deleted ConfigMap %q`, testName),
-			rtesting.NewEvent(resource, scheme, corev1.EventTypeWarning, "FinalizerPatchFailed",
-				`Failed to patch finalizer %q: inducing failure for patch TestResource`, testFinalizer),
-		},
-		ExpectDeletes: []rtesting.DeleteRef{
-			rtesting.NewDeleteRefFromObject(configMapGiven, scheme),
-		},
-		ExpectPatches: []rtesting.PatchRef{
-			{
-				Group:     "testing.reconciler.runtime",
-				Kind:      "TestResource",
-				Namespace: testNamespace,
-				Name:      testName,
-				PatchType: types.MergePatchType,
-				Patch:     []byte(`{"metadata":{"finalizers":null,"resourceVersion":"999"}}`),
+		"delete child": {
+			Resource: resourceReady,
+			GivenObjects: []client.Object{
+				configMapGiven,
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return defaultChildReconciler(c)
+				},
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Deleted",
+					`Deleted ConfigMap %q`, testName),
+			},
+			ExpectDeletes: []rtesting.DeleteRef{
+				rtesting.NewDeleteRefFromObject(configMapGiven, scheme),
 			},
 		},
-		ShouldErr: true,
-	}, {
-		Name: "error updating child",
-		Resource: resourceReady.
-			SpecDie(func(d *dies.TestResourceSpecDie) {
-				d.AddField("foo", "bar")
-				d.AddField("new", "field")
-			}).
-			StatusDie(func(d *dies.TestResourceStatusDie) {
-				d.AddField("foo", "bar")
-			}),
-		GivenObjects: []client.Object{
-			configMapGiven,
-		},
-		WithReactors: []rtesting.ReactionFunc{
-			rtesting.InduceFailure("update", "ConfigMap"),
-		},
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return defaultChildReconciler(c)
-			},
-		},
-		ExpectEvents: []rtesting.Event{
-			rtesting.NewEvent(resource, scheme, corev1.EventTypeWarning, "UpdateFailed",
-				`Failed to update ConfigMap %q: inducing failure for update ConfigMap`, testName),
-		},
-		ExpectUpdates: []client.Object{
-			configMapGiven.
-				AddData("new", "field"),
-		},
-		ShouldErr: true,
-	}, {
-		Name:     "error deleting child",
-		Resource: resourceReady,
-		GivenObjects: []client.Object{
-			configMapGiven,
-		},
-		WithReactors: []rtesting.ReactionFunc{
-			rtesting.InduceFailure("delete", "ConfigMap"),
-		},
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return defaultChildReconciler(c)
-			},
-		},
-		ExpectEvents: []rtesting.Event{
-			rtesting.NewEvent(resource, scheme, corev1.EventTypeWarning, "DeleteFailed",
-				`Failed to delete ConfigMap %q: inducing failure for delete ConfigMap`, testName),
-		},
-		ExpectDeletes: []rtesting.DeleteRef{
-			rtesting.NewDeleteRefFromObject(configMapGiven, scheme),
-		},
-		ShouldErr: true,
-	}, {
-		Name: "error deleting duplicate children",
-		Resource: resource.
-			SpecDie(func(d *dies.TestResourceSpecDie) {
-				d.AddField("foo", "bar")
-			}),
-		GivenObjects: []client.Object{
-			configMapGiven.
+		"delete child, clearing finalizer": {
+			Resource: resourceReady.
 				MetadataDie(func(d *diemetav1.ObjectMetaDie) {
-					d.Name("extra-child-1")
+					d.Finalizers(testFinalizer)
 				}),
-			configMapGiven.
+			GivenObjects: []client.Object{
+				configMapGiven.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.OwnerReferences()
+					}),
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					r := defaultChildReconciler(c)
+					r.Finalizer = testFinalizer
+					r.SkipOwnerReference = true
+					r.OurChild = func(parent, child client.Object) bool { return true }
+					return r
+				},
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Deleted",
+					`Deleted ConfigMap %q`, testName),
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "FinalizerPatched",
+					`Patched finalizer %q`, testFinalizer),
+			},
+			ExpectResource: resourceReady.
 				MetadataDie(func(d *diemetav1.ObjectMetaDie) {
-					d.Name("extra-child-2")
+					d.Finalizers()
+					d.ResourceVersion("1000")
 				}),
-		},
-		WithReactors: []rtesting.ReactionFunc{
-			rtesting.InduceFailure("delete", "ConfigMap"),
-		},
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return defaultChildReconciler(c)
+			ExpectDeletes: []rtesting.DeleteRef{
+				rtesting.NewDeleteRefFromObject(configMapGiven, scheme),
+			},
+			ExpectPatches: []rtesting.PatchRef{
+				{
+					Group:     "testing.reconciler.runtime",
+					Kind:      "TestResource",
+					Namespace: testNamespace,
+					Name:      testName,
+					PatchType: types.MergePatchType,
+					Patch:     []byte(`{"metadata":{"finalizers":null,"resourceVersion":"999"}}`),
+				},
 			},
 		},
-		ExpectEvents: []rtesting.Event{
-			rtesting.NewEvent(resource, scheme, corev1.EventTypeWarning, "DeleteFailed",
-				`Failed to delete ConfigMap %q: inducing failure for delete ConfigMap`, "extra-child-1"),
-		},
-		ExpectDeletes: []rtesting.DeleteRef{
-			{Group: "", Kind: "ConfigMap", Namespace: testNamespace, Name: "extra-child-1"},
-		},
-		ShouldErr: true,
-	}, {
-		Name:     "error creating desired child",
-		Resource: resource,
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				r := defaultChildReconciler(c)
-				r.DesiredChild = func(ctx context.Context, parent *resources.TestResource) (*corev1.ConfigMap, error) {
-					return nil, fmt.Errorf("test error")
-				}
-				return r
+		"delete child, preserve other finalizer": {
+			Resource: resourceReady.
+				MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+					d.Finalizers("some.other.finalizer")
+				}),
+			GivenObjects: []client.Object{
+				configMapGiven.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.OwnerReferences()
+					}),
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					r := defaultChildReconciler(c)
+					r.Finalizer = testFinalizer
+					r.SkipOwnerReference = true
+					r.OurChild = func(parent, child client.Object) bool { return true }
+					return r
+				},
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Deleted",
+					`Deleted ConfigMap %q`, testName),
+			},
+			ExpectDeletes: []rtesting.DeleteRef{
+				rtesting.NewDeleteRefFromObject(configMapGiven, scheme),
 			},
 		},
-		ShouldErr: true,
-	}}
+		"ignore extraneous children": {
+			Resource: resourceReady,
+			GivenObjects: []client.Object{
+				configMapGiven,
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					r := defaultChildReconciler(c)
+					r.OurChild = func(parent *resources.TestResource, child *corev1.ConfigMap) bool {
+						return false
+					}
+					return r
+				},
+			},
+		},
+		"delete duplicate children": {
+			Resource: resource.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
+				}),
+			GivenObjects: []client.Object{
+				configMapGiven.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.Name("extra-child-1")
+					}),
+				configMapGiven.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.Name("extra-child-2")
+					}),
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return defaultChildReconciler(c)
+				},
+			},
+			ExpectResource: resourceReady.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
+				}).
+				StatusDie(func(d *dies.TestResourceStatusDie) {
+					d.AddField("foo", "bar")
+				}),
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Deleted",
+					`Deleted ConfigMap %q`, "extra-child-1"),
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Deleted",
+					`Deleted ConfigMap %q`, "extra-child-2"),
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Created",
+					`Created ConfigMap %q`, testName),
+			},
+			ExpectDeletes: []rtesting.DeleteRef{
+				{Group: "", Kind: "ConfigMap", Namespace: testNamespace, Name: "extra-child-1"},
+				{Group: "", Kind: "ConfigMap", Namespace: testNamespace, Name: "extra-child-2"},
+			},
+			ExpectCreates: []client.Object{
+				configMapCreate,
+			},
+		},
+		"delete child durring finalization": {
+			Resource: resourceReady.
+				MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+					d.DeletionTimestamp(&now)
+					d.Finalizers(testFinalizer)
+				}),
+			GivenObjects: []client.Object{
+				configMapGiven.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.OwnerReferences()
+					}),
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					r := defaultChildReconciler(c)
+					r.Finalizer = testFinalizer
+					r.SkipOwnerReference = true
+					r.OurChild = func(parent, child client.Object) bool { return true }
+					return r
+				},
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Deleted",
+					`Deleted ConfigMap %q`, testName),
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "FinalizerPatched",
+					`Patched finalizer %q`, testFinalizer),
+			},
+			ExpectResource: resourceReady.
+				MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+					d.DeletionTimestamp(&now)
+					d.Finalizers()
+					d.ResourceVersion("1000")
+				}),
+			ExpectDeletes: []rtesting.DeleteRef{
+				rtesting.NewDeleteRefFromObject(configMapGiven, scheme),
+			},
+			ExpectPatches: []rtesting.PatchRef{
+				{
+					Group:     "testing.reconciler.runtime",
+					Kind:      "TestResource",
+					Namespace: testNamespace,
+					Name:      testName,
+					PatchType: types.MergePatchType,
+					Patch:     []byte(`{"metadata":{"finalizers":null,"resourceVersion":"999"}}`),
+				},
+			},
+		},
+		"child name collision": {
+			Resource: resourceReady.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
+				}),
+			WithReactors: []rtesting.ReactionFunc{
+				rtesting.InduceFailure("create", "ConfigMap", rtesting.InduceFailureOpts{
+					Error: apierrs.NewAlreadyExists(schema.GroupResource{}, testName),
+				}),
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return defaultChildReconciler(c)
+				},
+			},
+			ExpectResource: resourceReady.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
+				}).
+				StatusDie(func(d *dies.TestResourceStatusDie) {
+					d.ConditionsDie(
+						diemetav1.ConditionBlank.Type(apis.ConditionReady).Status(metav1.ConditionFalse).
+							Reason("NameConflict").Message(`"test-resource" already exists`),
+					)
+				}),
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeWarning, "CreationFailed",
+					"Failed to create ConfigMap %q:  %q already exists", testName, testName),
+			},
+			ExpectCreates: []client.Object{
+				configMapCreate,
+			},
+		},
+		"child name collision, stale informer cache": {
+			Resource: resourceReady.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
+				}),
+			APIGivenObjects: []client.Object{
+				configMapGiven,
+			},
+			WithReactors: []rtesting.ReactionFunc{
+				rtesting.InduceFailure("create", "ConfigMap", rtesting.InduceFailureOpts{
+					Error: apierrs.NewAlreadyExists(schema.GroupResource{}, testName),
+				}),
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return defaultChildReconciler(c)
+				},
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeWarning, "CreationFailed",
+					"Failed to create ConfigMap %q:  %q already exists", testName, testName),
+			},
+			ExpectCreates: []client.Object{
+				configMapCreate,
+			},
+			ShouldErr: true,
+		},
+		"preserve immutable fields": {
+			Resource: resourceReady.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
+				}).
+				StatusDie(func(d *dies.TestResourceStatusDie) {
+					d.AddField("foo", "bar")
+					d.AddField("immutable", "field")
+				}),
+			GivenObjects: []client.Object{
+				configMapGiven.
+					AddData("immutable", "field"),
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					r := defaultChildReconciler(c)
+					r.HarmonizeImmutableFields = func(current, desired *corev1.ConfigMap) {
+						desired.Data["immutable"] = current.Data["immutable"]
+					}
+					return r
+				},
+			},
+		},
+		"status only reconcile": {
+			Resource: resource,
+			GivenObjects: []client.Object{
+				configMapGiven,
+			},
+			ExpectResource: resourceReady.
+				StatusDie(func(d *dies.TestResourceStatusDie) {
+					d.AddField("foo", "bar")
+				}),
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					r := defaultChildReconciler(c)
+					r.DesiredChild = func(ctx context.Context, parent *resources.TestResource) (*corev1.ConfigMap, error) {
+						return nil, reconcilers.OnlyReconcileChildStatus
+					}
+					return r
+				},
+			},
+		},
+		"sanitize child before logging": {
+			Resource: resource.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
+				}),
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					r := defaultChildReconciler(c)
+					r.Sanitize = func(child *corev1.ConfigMap) interface{} {
+						return child.Name
+					}
+					return r
+				},
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Created",
+					`Created ConfigMap %q`, testName),
+			},
+			ExpectResource: resourceReady.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
+				}).
+				StatusDie(func(d *dies.TestResourceStatusDie) {
+					d.AddField("foo", "bar")
+				}),
+			ExpectCreates: []client.Object{
+				configMapCreate,
+			},
+		},
+		"sanitize is mutation safe": {
+			Resource: resource.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
+				}),
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					r := defaultChildReconciler(c)
+					r.Sanitize = func(child *corev1.ConfigMap) interface{} {
+						child.Data["ignore"] = "me"
+						return child
+					}
+					return r
+				},
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Created",
+					`Created ConfigMap %q`, testName),
+			},
+			ExpectResource: resourceReady.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
+				}).
+				StatusDie(func(d *dies.TestResourceStatusDie) {
+					d.AddField("foo", "bar")
+				}),
+			ExpectCreates: []client.Object{
+				configMapCreate,
+			},
+		},
+		"error listing children": {
+			Resource: resourceReady,
+			WithReactors: []rtesting.ReactionFunc{
+				rtesting.InduceFailure("list", "ConfigMapList"),
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return defaultChildReconciler(c)
+				},
+			},
+			ShouldErr: true,
+		},
+		"error creating child": {
+			Resource: resource.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
+				}),
+			WithReactors: []rtesting.ReactionFunc{
+				rtesting.InduceFailure("create", "ConfigMap"),
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return defaultChildReconciler(c)
+				},
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeWarning, "CreationFailed",
+					`Failed to create ConfigMap %q: inducing failure for create ConfigMap`, testName),
+			},
+			ExpectCreates: []client.Object{
+				configMapCreate,
+			},
+			ShouldErr: true,
+		},
+		"error adding finalizer": {
+			Resource: resource.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
+				}),
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					r := defaultChildReconciler(c)
+					r.Finalizer = testFinalizer
+					r.SkipOwnerReference = true
+					r.OurChild = func(parent, child client.Object) bool { return true }
+					return r
+				},
+			},
+			WithReactors: []rtesting.ReactionFunc{
+				rtesting.InduceFailure("patch", "TestResource"),
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeWarning, "FinalizerPatchFailed",
+					`Failed to patch finalizer %q: inducing failure for patch TestResource`, testFinalizer),
+			},
+			ExpectPatches: []rtesting.PatchRef{
+				{
+					Group:     "testing.reconciler.runtime",
+					Kind:      "TestResource",
+					Namespace: testNamespace,
+					Name:      testName,
+					PatchType: types.MergePatchType,
+					Patch:     []byte(`{"metadata":{"finalizers":["test.finalizer"],"resourceVersion":"999"}}`),
+				},
+			},
+			ShouldErr: true,
+		},
+		"error clearing finalizer": {
+			Resource: resourceReady.
+				MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+					d.Finalizers(testFinalizer)
+				}),
+			GivenObjects: []client.Object{
+				configMapGiven.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.OwnerReferences()
+					}),
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					r := defaultChildReconciler(c)
+					r.Finalizer = testFinalizer
+					r.SkipOwnerReference = true
+					r.OurChild = func(parent, child client.Object) bool { return true }
+					return r
+				},
+			},
+			WithReactors: []rtesting.ReactionFunc{
+				rtesting.InduceFailure("patch", "TestResource"),
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Deleted",
+					`Deleted ConfigMap %q`, testName),
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeWarning, "FinalizerPatchFailed",
+					`Failed to patch finalizer %q: inducing failure for patch TestResource`, testFinalizer),
+			},
+			ExpectDeletes: []rtesting.DeleteRef{
+				rtesting.NewDeleteRefFromObject(configMapGiven, scheme),
+			},
+			ExpectPatches: []rtesting.PatchRef{
+				{
+					Group:     "testing.reconciler.runtime",
+					Kind:      "TestResource",
+					Namespace: testNamespace,
+					Name:      testName,
+					PatchType: types.MergePatchType,
+					Patch:     []byte(`{"metadata":{"finalizers":null,"resourceVersion":"999"}}`),
+				},
+			},
+			ShouldErr: true,
+		},
+		"error updating child": {
+			Resource: resourceReady.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
+					d.AddField("new", "field")
+				}).
+				StatusDie(func(d *dies.TestResourceStatusDie) {
+					d.AddField("foo", "bar")
+				}),
+			GivenObjects: []client.Object{
+				configMapGiven,
+			},
+			WithReactors: []rtesting.ReactionFunc{
+				rtesting.InduceFailure("update", "ConfigMap"),
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return defaultChildReconciler(c)
+				},
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeWarning, "UpdateFailed",
+					`Failed to update ConfigMap %q: inducing failure for update ConfigMap`, testName),
+			},
+			ExpectUpdates: []client.Object{
+				configMapGiven.
+					AddData("new", "field"),
+			},
+			ShouldErr: true,
+		},
+		"error deleting child": {
+			Resource: resourceReady,
+			GivenObjects: []client.Object{
+				configMapGiven,
+			},
+			WithReactors: []rtesting.ReactionFunc{
+				rtesting.InduceFailure("delete", "ConfigMap"),
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return defaultChildReconciler(c)
+				},
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeWarning, "DeleteFailed",
+					`Failed to delete ConfigMap %q: inducing failure for delete ConfigMap`, testName),
+			},
+			ExpectDeletes: []rtesting.DeleteRef{
+				rtesting.NewDeleteRefFromObject(configMapGiven, scheme),
+			},
+			ShouldErr: true,
+		},
+		"error deleting duplicate children": {
+			Resource: resource.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
+				}),
+			GivenObjects: []client.Object{
+				configMapGiven.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.Name("extra-child-1")
+					}),
+				configMapGiven.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.Name("extra-child-2")
+					}),
+			},
+			WithReactors: []rtesting.ReactionFunc{
+				rtesting.InduceFailure("delete", "ConfigMap"),
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return defaultChildReconciler(c)
+				},
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeWarning, "DeleteFailed",
+					`Failed to delete ConfigMap %q: inducing failure for delete ConfigMap`, "extra-child-1"),
+			},
+			ExpectDeletes: []rtesting.DeleteRef{
+				{Group: "", Kind: "ConfigMap", Namespace: testNamespace, Name: "extra-child-1"},
+			},
+			ShouldErr: true,
+		},
+		"error creating desired child": {
+			Resource: resource,
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					r := defaultChildReconciler(c)
+					r.DesiredChild = func(ctx context.Context, parent *resources.TestResource) (*corev1.ConfigMap, error) {
+						return nil, fmt.Errorf("test error")
+					}
+					return r
+				},
+			},
+			ShouldErr: true,
+		},
+	}
 
 	rts.Run(t, scheme, func(t *testing.T, rtc *rtesting.SubReconcilerTestCase, c reconcilers.Config) reconcilers.SubReconciler {
 		return rtc.Metadata["SubReconciler"].(func(*testing.T, reconcilers.Config) reconcilers.SubReconciler)(t, c)
@@ -2142,226 +2150,227 @@ func TestSequence(t *testing.T) {
 			)
 		})
 
-	rts := rtesting.SubReconcilerTestSuite{{
-		Name:     "sub reconciler erred",
-		Resource: resource,
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return reconcilers.Sequence{
-					&reconcilers.SyncReconciler{
-						Sync: func(ctx context.Context, resource *resources.TestResource) error {
-							return fmt.Errorf("reconciler error")
+	rts := rtesting.SubReconcilerTests{
+		"sub reconciler erred": {
+			Resource: resource,
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return reconcilers.Sequence{
+						&reconcilers.SyncReconciler{
+							Sync: func(ctx context.Context, resource *resources.TestResource) error {
+								return fmt.Errorf("reconciler error")
+							},
 						},
-					},
-				}
+					}
+				},
 			},
+			ShouldErr: true,
 		},
-		ShouldErr: true,
-	}, {
-		Name:     "preserves result, Requeue",
-		Resource: resource,
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return &reconcilers.SyncReconciler{
-					Sync: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
-						return ctrl.Result{Requeue: true}, nil
-					},
-				}
-			},
-		},
-		ExpectedResult: ctrl.Result{Requeue: true},
-	}, {
-		Name:     "preserves result, RequeueAfter",
-		Resource: resource,
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return reconcilers.Sequence{
-					&reconcilers.SyncReconciler{
-						Sync: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
-							return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
-						},
-					},
-				}
-			},
-		},
-		ExpectedResult: ctrl.Result{RequeueAfter: 1 * time.Minute},
-	}, {
-		Name:     "ignores result on err",
-		Resource: resource,
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return reconcilers.Sequence{
-					&reconcilers.SyncReconciler{
-						Sync: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
-							return ctrl.Result{Requeue: true}, fmt.Errorf("test error")
-						},
-					},
-				}
-			},
-		},
-		ExpectedResult: ctrl.Result{},
-		ShouldErr:      true,
-	}, {
-		Name:     "Requeue + empty => Requeue",
-		Resource: resource,
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return reconcilers.Sequence{
-					&reconcilers.SyncReconciler{
+		"preserves result, Requeue": {
+			Resource: resource,
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return &reconcilers.SyncReconciler{
 						Sync: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
 							return ctrl.Result{Requeue: true}, nil
 						},
-					},
-					&reconcilers.SyncReconciler{
-						Sync: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
-							return ctrl.Result{}, nil
-						},
-					},
-				}
+					}
+				},
 			},
+			ExpectedResult: ctrl.Result{Requeue: true},
 		},
-		ExpectedResult: ctrl.Result{Requeue: true},
-	}, {
-		Name:     "empty + Requeue => Requeue",
-		Resource: resource,
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return reconcilers.Sequence{
-					&reconcilers.SyncReconciler{
-						Sync: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
-							return ctrl.Result{}, nil
+		"preserves result, RequeueAfter": {
+			Resource: resource,
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return reconcilers.Sequence{
+						&reconcilers.SyncReconciler{
+							Sync: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
+								return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
+							},
 						},
-					},
-					&reconcilers.SyncReconciler{
-						Sync: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
-							return ctrl.Result{Requeue: true}, nil
-						},
-					},
-				}
+					}
+				},
 			},
+			ExpectedResult: ctrl.Result{RequeueAfter: 1 * time.Minute},
 		},
-		ExpectedResult: ctrl.Result{Requeue: true},
-	}, {
-		Name:     "RequeueAfter + empty => RequeueAfter",
-		Resource: resource,
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return reconcilers.Sequence{
-					&reconcilers.SyncReconciler{
-						Sync: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
-							return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
+		"ignores result on err": {
+			Resource: resource,
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return reconcilers.Sequence{
+						&reconcilers.SyncReconciler{
+							Sync: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
+								return ctrl.Result{Requeue: true}, fmt.Errorf("test error")
+							},
 						},
-					},
-					&reconcilers.SyncReconciler{
-						Sync: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
-							return ctrl.Result{}, nil
-						},
-					},
-				}
+					}
+				},
 			},
+			ExpectedResult: ctrl.Result{},
+			ShouldErr:      true,
 		},
-		ExpectedResult: ctrl.Result{RequeueAfter: 1 * time.Minute},
-	}, {
-		Name:     "empty + RequeueAfter => RequeueAfter",
-		Resource: resource,
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return reconcilers.Sequence{
-					&reconcilers.SyncReconciler{
-						Sync: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
-							return ctrl.Result{}, nil
+		"Requeue + empty => Requeue": {
+			Resource: resource,
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return reconcilers.Sequence{
+						&reconcilers.SyncReconciler{
+							Sync: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
+								return ctrl.Result{Requeue: true}, nil
+							},
 						},
-					},
-					&reconcilers.SyncReconciler{
-						Sync: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
-							return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
+						&reconcilers.SyncReconciler{
+							Sync: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
+								return ctrl.Result{}, nil
+							},
 						},
-					},
-				}
+					}
+				},
 			},
+			ExpectedResult: ctrl.Result{Requeue: true},
 		},
-		ExpectedResult: ctrl.Result{RequeueAfter: 1 * time.Minute},
-	}, {
-		Name:     "RequeueAfter + Requeue => RequeueAfter",
-		Resource: resource,
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return reconcilers.Sequence{
-					&reconcilers.SyncReconciler{
-						Sync: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
-							return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
+		"empty + Requeue => Requeue": {
+			Resource: resource,
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return reconcilers.Sequence{
+						&reconcilers.SyncReconciler{
+							Sync: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
+								return ctrl.Result{}, nil
+							},
 						},
-					},
-					&reconcilers.SyncReconciler{
-						Sync: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
-							return ctrl.Result{Requeue: true}, nil
+						&reconcilers.SyncReconciler{
+							Sync: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
+								return ctrl.Result{Requeue: true}, nil
+							},
 						},
-					},
-				}
+					}
+				},
 			},
+			ExpectedResult: ctrl.Result{Requeue: true},
 		},
-		ExpectedResult: ctrl.Result{RequeueAfter: 1 * time.Minute},
-	}, {
-		Name:     "Requeue + RequeueAfter => RequeueAfter",
-		Resource: resource,
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return reconcilers.Sequence{
-					&reconcilers.SyncReconciler{
-						Sync: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
-							return ctrl.Result{Requeue: true}, nil
+		"RequeueAfter + empty => RequeueAfter": {
+			Resource: resource,
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return reconcilers.Sequence{
+						&reconcilers.SyncReconciler{
+							Sync: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
+								return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
+							},
 						},
-					},
-					&reconcilers.SyncReconciler{
-						Sync: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
-							return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
+						&reconcilers.SyncReconciler{
+							Sync: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
+								return ctrl.Result{}, nil
+							},
 						},
-					},
-				}
+					}
+				},
 			},
+			ExpectedResult: ctrl.Result{RequeueAfter: 1 * time.Minute},
 		},
-		ExpectedResult: ctrl.Result{RequeueAfter: 1 * time.Minute},
-	}, {
-		Name:     "RequeueAfter(1m) + RequeueAfter(2m) => RequeueAfter(1m)",
-		Resource: resource,
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return reconcilers.Sequence{
-					&reconcilers.SyncReconciler{
-						Sync: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
-							return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
+		"empty + RequeueAfter => RequeueAfter": {
+			Resource: resource,
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return reconcilers.Sequence{
+						&reconcilers.SyncReconciler{
+							Sync: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
+								return ctrl.Result{}, nil
+							},
 						},
-					},
-					&reconcilers.SyncReconciler{
-						Sync: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
-							return ctrl.Result{RequeueAfter: 2 * time.Minute}, nil
+						&reconcilers.SyncReconciler{
+							Sync: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
+								return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
+							},
 						},
-					},
-				}
+					}
+				},
 			},
+			ExpectedResult: ctrl.Result{RequeueAfter: 1 * time.Minute},
 		},
-		ExpectedResult: ctrl.Result{RequeueAfter: 1 * time.Minute},
-	}, {
-		Name:     "RequeueAfter(2m) + RequeueAfter(1m) => RequeueAfter(1m)",
-		Resource: resource,
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return reconcilers.Sequence{
-					&reconcilers.SyncReconciler{
-						Sync: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
-							return ctrl.Result{RequeueAfter: 2 * time.Minute}, nil
+		"RequeueAfter + Requeue => RequeueAfter": {
+			Resource: resource,
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return reconcilers.Sequence{
+						&reconcilers.SyncReconciler{
+							Sync: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
+								return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
+							},
 						},
-					},
-					&reconcilers.SyncReconciler{
-						Sync: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
-							return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
+						&reconcilers.SyncReconciler{
+							Sync: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
+								return ctrl.Result{Requeue: true}, nil
+							},
 						},
-					},
-				}
+					}
+				},
 			},
+			ExpectedResult: ctrl.Result{RequeueAfter: 1 * time.Minute},
 		},
-		ExpectedResult: ctrl.Result{RequeueAfter: 1 * time.Minute},
-	}}
+		"Requeue + RequeueAfter => RequeueAfter": {
+			Resource: resource,
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return reconcilers.Sequence{
+						&reconcilers.SyncReconciler{
+							Sync: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
+								return ctrl.Result{Requeue: true}, nil
+							},
+						},
+						&reconcilers.SyncReconciler{
+							Sync: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
+								return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
+							},
+						},
+					}
+				},
+			},
+			ExpectedResult: ctrl.Result{RequeueAfter: 1 * time.Minute},
+		},
+		"RequeueAfter(1m) + RequeueAfter(2m) => RequeueAfter(1m)": {
+			Resource: resource,
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return reconcilers.Sequence{
+						&reconcilers.SyncReconciler{
+							Sync: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
+								return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
+							},
+						},
+						&reconcilers.SyncReconciler{
+							Sync: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
+								return ctrl.Result{RequeueAfter: 2 * time.Minute}, nil
+							},
+						},
+					}
+				},
+			},
+			ExpectedResult: ctrl.Result{RequeueAfter: 1 * time.Minute},
+		},
+		"RequeueAfter(2m) + RequeueAfter(1m) => RequeueAfter(1m)": {
+			Resource: resource,
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return reconcilers.Sequence{
+						&reconcilers.SyncReconciler{
+							Sync: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
+								return ctrl.Result{RequeueAfter: 2 * time.Minute}, nil
+							},
+						},
+						&reconcilers.SyncReconciler{
+							Sync: func(ctx context.Context, resource *resources.TestResource) (ctrl.Result, error) {
+								return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
+							},
+						},
+					}
+				},
+			},
+			ExpectedResult: ctrl.Result{RequeueAfter: 1 * time.Minute},
+		},
+	}
 
 	rts.Run(t, scheme, func(t *testing.T, rtc *rtesting.SubReconcilerTestCase, c reconcilers.Config) reconcilers.SubReconciler {
 		return rtc.Metadata["SubReconciler"].(func(*testing.T, reconcilers.Config) reconcilers.SubReconciler)(t, c)
@@ -2388,180 +2397,181 @@ func TestCastResource(t *testing.T) {
 			)
 		})
 
-	rts := rtesting.SubReconcilerTestSuite{{
-		Name: "sync success",
-		Resource: resource.
-			SpecDie(func(d *dies.TestResourceSpecDie) {
-				d.TemplateDie(func(d *diecorev1.PodTemplateSpecDie) {
-					d.SpecDie(func(d *diecorev1.PodSpecDie) {
-						d.ContainerDie("test-container", func(d *diecorev1.ContainerDie) {})
+	rts := rtesting.SubReconcilerTests{
+		"sync success": {
+			Resource: resource.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.TemplateDie(func(d *diecorev1.PodTemplateSpecDie) {
+						d.SpecDie(func(d *diecorev1.PodSpecDie) {
+							d.ContainerDie("test-container", func(d *diecorev1.ContainerDie) {})
+						})
 					})
-				})
-			}),
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return &reconcilers.CastResource{
-					Type: &appsv1.Deployment{},
-					Reconciler: &reconcilers.SyncReconciler{
-						Sync: func(ctx context.Context, resource *appsv1.Deployment) error {
-							reconcilers.RetrieveConfigOrDie(ctx).
-								Recorder.Event(resource, corev1.EventTypeNormal, "Test",
-								resource.Spec.Template.Spec.Containers[0].Name)
-							return nil
+				}),
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return &reconcilers.CastResource{
+						Type: &appsv1.Deployment{},
+						Reconciler: &reconcilers.SyncReconciler{
+							Sync: func(ctx context.Context, resource *appsv1.Deployment) error {
+								reconcilers.RetrieveConfigOrDie(ctx).
+									Recorder.Event(resource, corev1.EventTypeNormal, "Test",
+									resource.Spec.Template.Spec.Containers[0].Name)
+								return nil
+							},
 						},
-					},
-				}
+					}
+				},
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Test", "test-container"),
 			},
 		},
-		ExpectEvents: []rtesting.Event{
-			rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Test", "test-container"),
-		},
-	}, {
-		Name:     "cast mutation",
-		Resource: resource,
-		ExpectResource: resource.
-			SpecDie(func(d *dies.TestResourceSpecDie) {
-				d.TemplateDie(func(d *diecorev1.PodTemplateSpecDie) {
-					d.MetadataDie(func(d *diemetav1.ObjectMetaDie) {
-						d.Name("mutation")
+		"cast mutation": {
+			Resource: resource,
+			ExpectResource: resource.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.TemplateDie(func(d *diecorev1.PodTemplateSpecDie) {
+						d.MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+							d.Name("mutation")
+						})
 					})
-				})
-			}),
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return &reconcilers.CastResource{
-					Type: &appsv1.Deployment{},
-					Reconciler: &reconcilers.SyncReconciler{
-						Sync: func(ctx context.Context, resource *appsv1.Deployment) error {
-							// mutation that exists on the original resource and will be reflected
-							resource.Spec.Template.Name = "mutation"
-							// mutation that does not exists on the original resource and will be dropped
-							resource.Spec.Paused = true
-							return nil
+				}),
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return &reconcilers.CastResource{
+						Type: &appsv1.Deployment{},
+						Reconciler: &reconcilers.SyncReconciler{
+							Sync: func(ctx context.Context, resource *appsv1.Deployment) error {
+								// mutation that exists on the original resource and will be reflected
+								resource.Spec.Template.Name = "mutation"
+								// mutation that does not exists on the original resource and will be dropped
+								resource.Spec.Paused = true
+								return nil
+							},
 						},
-					},
-				}
+					}
+				},
 			},
 		},
-	}, {
-		Name:     "return subreconciler result",
-		Resource: resource,
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return &reconcilers.CastResource{
-					Type: &appsv1.Deployment{},
-					Reconciler: &reconcilers.SyncReconciler{
-						Sync: func(ctx context.Context, resource *appsv1.Deployment) (ctrl.Result, error) {
-							return ctrl.Result{Requeue: true}, nil
+		"return subreconciler result": {
+			Resource: resource,
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return &reconcilers.CastResource{
+						Type: &appsv1.Deployment{},
+						Reconciler: &reconcilers.SyncReconciler{
+							Sync: func(ctx context.Context, resource *appsv1.Deployment) (ctrl.Result, error) {
+								return ctrl.Result{Requeue: true}, nil
+							},
 						},
-					},
-				}
+					}
+				},
 			},
+			ExpectedResult: ctrl.Result{Requeue: true},
 		},
-		ExpectedResult: ctrl.Result{Requeue: true},
-	}, {
-		Name:     "return subreconciler err",
-		Resource: resource,
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return &reconcilers.CastResource{
-					Type: &appsv1.Deployment{},
-					Reconciler: &reconcilers.SyncReconciler{
-						Sync: func(ctx context.Context, resource *appsv1.Deployment) error {
-							return fmt.Errorf("subreconciler error")
+		"return subreconciler err": {
+			Resource: resource,
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return &reconcilers.CastResource{
+						Type: &appsv1.Deployment{},
+						Reconciler: &reconcilers.SyncReconciler{
+							Sync: func(ctx context.Context, resource *appsv1.Deployment) error {
+								return fmt.Errorf("subreconciler error")
+							},
 						},
-					},
-				}
+					}
+				},
 			},
+			ShouldErr: true,
 		},
-		ShouldErr: true,
-	}, {
-		Name: "subreconcilers must be compatible with cast value, not reconciled resource",
-		Resource: resource.
-			SpecDie(func(d *dies.TestResourceSpecDie) {
-				d.TemplateDie(func(d *diecorev1.PodTemplateSpecDie) {
-					d.SpecDie(func(d *diecorev1.PodSpecDie) {
-						d.ContainerDie("test-container", func(d *diecorev1.ContainerDie) {})
+		"subreconcilers must be compatible with cast value, not reconciled resource": {
+			Resource: resource.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.TemplateDie(func(d *diecorev1.PodTemplateSpecDie) {
+						d.SpecDie(func(d *diecorev1.PodSpecDie) {
+							d.ContainerDie("test-container", func(d *diecorev1.ContainerDie) {})
+						})
 					})
-				})
-			}),
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return &reconcilers.CastResource{
-					Type: &appsv1.Deployment{},
-					Reconciler: &reconcilers.SyncReconciler{
-						Sync: func(ctx context.Context, resource *resources.TestResource) error {
-							return nil
+				}),
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return &reconcilers.CastResource{
+						Type: &appsv1.Deployment{},
+						Reconciler: &reconcilers.SyncReconciler{
+							Sync: func(ctx context.Context, resource *resources.TestResource) error {
+								return nil
+							},
 						},
-					},
-				}
+					}
+				},
 			},
+			ShouldPanic: true,
 		},
-		ShouldPanic: true,
-	}, {
-		Name: "error for cast to different type than expected by sub reconciler",
-		Resource: resource.
-			SpecDie(func(d *dies.TestResourceSpecDie) {
-				d.TemplateDie(func(d *diecorev1.PodTemplateSpecDie) {
-					d.SpecDie(func(d *diecorev1.PodSpecDie) {
-						d.ContainerDie("test-container", func(d *diecorev1.ContainerDie) {})
+		"error for cast to different type than expected by sub reconciler": {
+			Resource: resource.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.TemplateDie(func(d *diecorev1.PodTemplateSpecDie) {
+						d.SpecDie(func(d *diecorev1.PodSpecDie) {
+							d.ContainerDie("test-container", func(d *diecorev1.ContainerDie) {})
+						})
 					})
-				})
-			}),
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return &reconcilers.CastResource{
-					Type: &appsv1.Deployment{},
-					Reconciler: &reconcilers.SyncReconciler{
-						Sync: func(ctx context.Context, resource *resources.TestResource) error {
-							return nil
+				}),
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return &reconcilers.CastResource{
+						Type: &appsv1.Deployment{},
+						Reconciler: &reconcilers.SyncReconciler{
+							Sync: func(ctx context.Context, resource *resources.TestResource) error {
+								return nil
+							},
 						},
-					},
-				}
+					}
+				},
 			},
+			ShouldPanic: true,
 		},
-		ShouldPanic: true,
-	}, {
-		Name: "marshal error",
-		Resource: resource.
-			SpecDie(func(d *dies.TestResourceSpecDie) {
-				d.ErrOnMarshal(true)
-			}),
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return &reconcilers.CastResource{
-					Type: &resources.TestResource{},
-					Reconciler: &reconcilers.SyncReconciler{
-						Sync: func(ctx context.Context, resource *resources.TestResource) error {
-							c.Recorder.Event(resource, corev1.EventTypeNormal, "Test", resource.Name)
-							return nil
+		"marshal error": {
+			Resource: resource.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.ErrOnMarshal(true)
+				}),
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return &reconcilers.CastResource{
+						Type: &resources.TestResource{},
+						Reconciler: &reconcilers.SyncReconciler{
+							Sync: func(ctx context.Context, resource *resources.TestResource) error {
+								c.Recorder.Event(resource, corev1.EventTypeNormal, "Test", resource.Name)
+								return nil
+							},
 						},
-					},
-				}
+					}
+				},
 			},
+			ShouldErr: true,
 		},
-		ShouldErr: true,
-	}, {
-		Name: "unmarshal error",
-		Resource: resource.
-			SpecDie(func(d *dies.TestResourceSpecDie) {
-				d.ErrOnUnmarshal(true)
-			}),
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
-				return &reconcilers.CastResource{
-					Type: &resources.TestResource{},
-					Reconciler: &reconcilers.SyncReconciler{
-						Sync: func(ctx context.Context, resource *resources.TestResource) error {
-							c.Recorder.Event(resource, corev1.EventTypeNormal, "Test", resource.Name)
-							return nil
+		"unmarshal error": {
+			Resource: resource.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.ErrOnUnmarshal(true)
+				}),
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return &reconcilers.CastResource{
+						Type: &resources.TestResource{},
+						Reconciler: &reconcilers.SyncReconciler{
+							Sync: func(ctx context.Context, resource *resources.TestResource) error {
+								c.Recorder.Event(resource, corev1.EventTypeNormal, "Test", resource.Name)
+								return nil
+							},
 						},
-					},
-				}
+					}
+				},
 			},
+			ShouldErr: true,
 		},
-		ShouldErr: true,
-	}}
+	}
 
 	rts.Run(t, scheme, func(t *testing.T, rtc *rtesting.SubReconcilerTestCase, c reconcilers.Config) reconcilers.SubReconciler {
 		return rtc.Metadata["SubReconciler"].(func(*testing.T, reconcilers.Config) reconcilers.SubReconciler)(t, c)
@@ -2582,43 +2592,44 @@ func TestWithConfig(t *testing.T) {
 			d.CreationTimestamp(metav1.NewTime(time.UnixMilli(1000)))
 		})
 
-	rts := rtesting.SubReconcilerTestSuite{{
-		Name:     "with config",
-		Resource: resource,
-		Metadata: map[string]interface{}{
-			"SubReconciler": func(t *testing.T, oc reconcilers.Config) reconcilers.SubReconciler {
-				c := reconcilers.Config{
-					Tracker: tracker.New(0),
-				}
+	rts := rtesting.SubReconcilerTests{
+		"with config": {
+			Resource: resource,
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, oc reconcilers.Config) reconcilers.SubReconciler {
+					c := reconcilers.Config{
+						Tracker: tracker.New(0),
+					}
 
-				return &reconcilers.WithConfig{
-					Config: func(ctx context.Context, _ reconcilers.Config) (reconcilers.Config, error) {
-						return c, nil
-					},
-					Reconciler: &reconcilers.SyncReconciler{
-						Sync: func(ctx context.Context, parent *resources.TestResource) error {
-							rc := reconcilers.RetrieveConfigOrDie(ctx)
-							roc := reconcilers.RetrieveOriginalConfigOrDie(ctx)
-
-							if rc != c {
-								t.Errorf("unexpected config")
-							}
-							if roc != oc {
-								t.Errorf("unexpected original config")
-							}
-
-							oc.Recorder.Event(resource, corev1.EventTypeNormal, "AllGood", "")
-
-							return nil
+					return &reconcilers.WithConfig{
+						Config: func(ctx context.Context, _ reconcilers.Config) (reconcilers.Config, error) {
+							return c, nil
 						},
-					},
-				}
+						Reconciler: &reconcilers.SyncReconciler{
+							Sync: func(ctx context.Context, parent *resources.TestResource) error {
+								rc := reconcilers.RetrieveConfigOrDie(ctx)
+								roc := reconcilers.RetrieveOriginalConfigOrDie(ctx)
+
+								if rc != c {
+									t.Errorf("unexpected config")
+								}
+								if roc != oc {
+									t.Errorf("unexpected original config")
+								}
+
+								oc.Recorder.Event(resource, corev1.EventTypeNormal, "AllGood", "")
+
+								return nil
+							},
+						},
+					}
+				},
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "AllGood", ""),
 			},
 		},
-		ExpectEvents: []rtesting.Event{
-			rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "AllGood", ""),
-		},
-	}}
+	}
 
 	rts.Run(t, scheme, func(t *testing.T, rtc *rtesting.SubReconcilerTestCase, c reconcilers.Config) reconcilers.SubReconciler {
 		return rtc.Metadata["SubReconciler"].(func(*testing.T, reconcilers.Config) reconcilers.SubReconciler)(t, c)
@@ -2642,127 +2653,128 @@ func TestWithFinalizer(t *testing.T) {
 			d.CreationTimestamp(metav1.NewTime(time.UnixMilli(1000)))
 		})
 
-	rts := rtesting.SubReconcilerTestSuite{{
-		Name: "in sync",
-		Resource: resource.
-			MetadataDie(func(d *diemetav1.ObjectMetaDie) {
-				d.Finalizers(testFinalizer)
-			}),
-		ExpectEvents: []rtesting.Event{
-			rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Sync", ""),
-		},
-	}, {
-		Name:     "add finalizer",
-		Resource: resource,
-		ExpectResource: resource.
-			MetadataDie(func(d *diemetav1.ObjectMetaDie) {
-				d.Finalizers(testFinalizer)
-				d.ResourceVersion("1000")
-			}),
-		ExpectEvents: []rtesting.Event{
-			rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "FinalizerPatched",
-				`Patched finalizer %q`, testFinalizer),
-			rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Sync", ""),
-		},
-		ExpectPatches: []rtesting.PatchRef{
-			{
-				Group:     "testing.reconciler.runtime",
-				Kind:      "TestResource",
-				Namespace: testNamespace,
-				Name:      testName,
-				PatchType: types.MergePatchType,
-				Patch:     []byte(`{"metadata":{"finalizers":["test-finalizer"],"resourceVersion":"999"}}`),
+	rts := rtesting.SubReconcilerTests{
+		"in sync": {
+			Resource: resource.
+				MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+					d.Finalizers(testFinalizer)
+				}),
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Sync", ""),
 			},
 		},
-	}, {
-		Name:     "error adding finalizer",
-		Resource: resource,
-		WithReactors: []rtesting.ReactionFunc{
-			rtesting.InduceFailure("patch", "TestResource"),
-		},
-		ShouldErr: true,
-		ExpectEvents: []rtesting.Event{
-			rtesting.NewEvent(resource, scheme, corev1.EventTypeWarning, "FinalizerPatchFailed",
-				`Failed to patch finalizer %q: inducing failure for patch TestResource`, testFinalizer),
-		},
-		ExpectPatches: []rtesting.PatchRef{
-			{
-				Group:     "testing.reconciler.runtime",
-				Kind:      "TestResource",
-				Namespace: testNamespace,
-				Name:      testName,
-				PatchType: types.MergePatchType,
-				Patch:     []byte(`{"metadata":{"finalizers":["test-finalizer"],"resourceVersion":"999"}}`),
+		"add finalizer": {
+			Resource: resource,
+			ExpectResource: resource.
+				MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+					d.Finalizers(testFinalizer)
+					d.ResourceVersion("1000")
+				}),
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "FinalizerPatched",
+					`Patched finalizer %q`, testFinalizer),
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Sync", ""),
+			},
+			ExpectPatches: []rtesting.PatchRef{
+				{
+					Group:     "testing.reconciler.runtime",
+					Kind:      "TestResource",
+					Namespace: testNamespace,
+					Name:      testName,
+					PatchType: types.MergePatchType,
+					Patch:     []byte(`{"metadata":{"finalizers":["test-finalizer"],"resourceVersion":"999"}}`),
+				},
 			},
 		},
-	}, {
-		Name: "clear finalizer",
-		Resource: resource.
-			MetadataDie(func(d *diemetav1.ObjectMetaDie) {
-				d.DeletionTimestamp(now)
-				d.Finalizers(testFinalizer)
-			}),
-		ExpectResource: resource.
-			MetadataDie(func(d *diemetav1.ObjectMetaDie) {
-				d.DeletionTimestamp(now)
-				d.ResourceVersion("1000")
-			}),
-		ExpectEvents: []rtesting.Event{
-			rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Finalize", ""),
-			rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "FinalizerPatched",
-				`Patched finalizer %q`, testFinalizer),
-		},
-		ExpectPatches: []rtesting.PatchRef{
-			{
-				Group:     "testing.reconciler.runtime",
-				Kind:      "TestResource",
-				Namespace: testNamespace,
-				Name:      testName,
-				PatchType: types.MergePatchType,
-				Patch:     []byte(`{"metadata":{"finalizers":null,"resourceVersion":"999"}}`),
+		"error adding finalizer": {
+			Resource: resource,
+			WithReactors: []rtesting.ReactionFunc{
+				rtesting.InduceFailure("patch", "TestResource"),
+			},
+			ShouldErr: true,
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeWarning, "FinalizerPatchFailed",
+					`Failed to patch finalizer %q: inducing failure for patch TestResource`, testFinalizer),
+			},
+			ExpectPatches: []rtesting.PatchRef{
+				{
+					Group:     "testing.reconciler.runtime",
+					Kind:      "TestResource",
+					Namespace: testNamespace,
+					Name:      testName,
+					PatchType: types.MergePatchType,
+					Patch:     []byte(`{"metadata":{"finalizers":["test-finalizer"],"resourceVersion":"999"}}`),
+				},
 			},
 		},
-	}, {
-		Name: "error clearing finalizer",
-		Resource: resource.
-			MetadataDie(func(d *diemetav1.ObjectMetaDie) {
-				d.DeletionTimestamp(now)
-				d.Finalizers(testFinalizer)
-			}),
-		WithReactors: []rtesting.ReactionFunc{
-			rtesting.InduceFailure("patch", "TestResource"),
-		},
-		ShouldErr: true,
-		ExpectEvents: []rtesting.Event{
-			rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Finalize", ""),
-			rtesting.NewEvent(resource, scheme, corev1.EventTypeWarning, "FinalizerPatchFailed",
-				`Failed to patch finalizer %q: inducing failure for patch TestResource`, testFinalizer),
-		},
-		ExpectPatches: []rtesting.PatchRef{
-			{
-				Group:     "testing.reconciler.runtime",
-				Kind:      "TestResource",
-				Namespace: testNamespace,
-				Name:      testName,
-				PatchType: types.MergePatchType,
-				Patch:     []byte(`{"metadata":{"finalizers":null,"resourceVersion":"999"}}`),
+		"clear finalizer": {
+			Resource: resource.
+				MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+					d.DeletionTimestamp(now)
+					d.Finalizers(testFinalizer)
+				}),
+			ExpectResource: resource.
+				MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+					d.DeletionTimestamp(now)
+					d.ResourceVersion("1000")
+				}),
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Finalize", ""),
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "FinalizerPatched",
+					`Patched finalizer %q`, testFinalizer),
+			},
+			ExpectPatches: []rtesting.PatchRef{
+				{
+					Group:     "testing.reconciler.runtime",
+					Kind:      "TestResource",
+					Namespace: testNamespace,
+					Name:      testName,
+					PatchType: types.MergePatchType,
+					Patch:     []byte(`{"metadata":{"finalizers":null,"resourceVersion":"999"}}`),
+				},
 			},
 		},
-	}, {
-		Name: "keep finalizer on error",
-		Resource: resource.
-			MetadataDie(func(d *diemetav1.ObjectMetaDie) {
-				d.DeletionTimestamp(now)
-				d.Finalizers(testFinalizer)
-			}),
-		ShouldErr: true,
-		ExpectEvents: []rtesting.Event{
-			rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Finalize", ""),
+		"error clearing finalizer": {
+			Resource: resource.
+				MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+					d.DeletionTimestamp(now)
+					d.Finalizers(testFinalizer)
+				}),
+			WithReactors: []rtesting.ReactionFunc{
+				rtesting.InduceFailure("patch", "TestResource"),
+			},
+			ShouldErr: true,
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Finalize", ""),
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeWarning, "FinalizerPatchFailed",
+					`Failed to patch finalizer %q: inducing failure for patch TestResource`, testFinalizer),
+			},
+			ExpectPatches: []rtesting.PatchRef{
+				{
+					Group:     "testing.reconciler.runtime",
+					Kind:      "TestResource",
+					Namespace: testNamespace,
+					Name:      testName,
+					PatchType: types.MergePatchType,
+					Patch:     []byte(`{"metadata":{"finalizers":null,"resourceVersion":"999"}}`),
+				},
+			},
 		},
-		Metadata: map[string]interface{}{
-			"FinalizerError": fmt.Errorf("finalize error"),
+		"keep finalizer on error": {
+			Resource: resource.
+				MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+					d.DeletionTimestamp(now)
+					d.Finalizers(testFinalizer)
+				}),
+			ShouldErr: true,
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Finalize", ""),
+			},
+			Metadata: map[string]interface{}{
+				"FinalizerError": fmt.Errorf("finalize error"),
+			},
 		},
-	}}
+	}
 
 	rts.Run(t, scheme, func(t *testing.T, rtc *rtesting.SubReconcilerTestCase, c reconcilers.Config) reconcilers.SubReconciler {
 		var syncErr, finalizeErr error

--- a/testing/reconciler.go
+++ b/testing/reconciler.go
@@ -92,7 +92,8 @@ type ReconcilerTestCase struct {
 // VerifyFunc is a verification function
 type VerifyFunc func(t *testing.T, result controllerruntime.Result, err error)
 
-// ReconcilerTests represents a map of reconciler test cases. The map key is the name of each test case.
+// ReconcilerTests represents a map of reconciler test cases. The map key is the name of each test
+// case. Test cases are executed in random order.
 type ReconcilerTests map[string]ReconcilerTestCase
 
 // Run executes the test cases.
@@ -106,7 +107,7 @@ func (rt ReconcilerTests) Run(t *testing.T, scheme *runtime.Scheme, factory Reco
 	rts.Run(t, scheme, factory)
 }
 
-// ReconcilerTestSuite represents a list of reconciler test cases.
+// ReconcilerTestSuite represents a list of reconciler test cases. The test cases are executed in order.
 type ReconcilerTestSuite []ReconcilerTestCase
 
 // Run executes the test case.

--- a/testing/reconciler.go
+++ b/testing/reconciler.go
@@ -92,6 +92,20 @@ type ReconcilerTestCase struct {
 // VerifyFunc is a verification function
 type VerifyFunc func(t *testing.T, result controllerruntime.Result, err error)
 
+// ReconcilerTests represents a map of reconciler test cases. The map key is the name of each test case.
+type ReconcilerTests map[string]ReconcilerTestCase
+
+// Run executes the test cases.
+func (rt ReconcilerTests) Run(t *testing.T, scheme *runtime.Scheme, factory ReconcilerFactory) {
+	t.Helper()
+	rts := ReconcilerTestSuite{}
+	for name, rtc := range rt {
+		rtc.Name = name
+		rts = append(rts, rtc)
+	}
+	rts.Run(t, scheme, factory)
+}
+
 // ReconcilerTestSuite represents a list of reconciler test cases.
 type ReconcilerTestSuite []ReconcilerTestCase
 

--- a/testing/subreconciler.go
+++ b/testing/subreconciler.go
@@ -94,6 +94,20 @@ type SubReconcilerTestCase struct {
 	CleanUp func(t *testing.T) error
 }
 
+// SubReconcilerTests represents a map of reconciler test cases. The map key is the name of each test case.
+type SubReconcilerTests map[string]SubReconcilerTestCase
+
+// Run executes the test cases.
+func (rt SubReconcilerTests) Run(t *testing.T, scheme *runtime.Scheme, factory SubReconcilerFactory) {
+	t.Helper()
+	rts := SubReconcilerTestSuite{}
+	for name, rtc := range rt {
+		rtc.Name = name
+		rts = append(rts, rtc)
+	}
+	rts.Run(t, scheme, factory)
+}
+
 // SubReconcilerTestSuite represents a list of subreconciler test cases.
 type SubReconcilerTestSuite []SubReconcilerTestCase
 

--- a/testing/subreconciler.go
+++ b/testing/subreconciler.go
@@ -94,7 +94,8 @@ type SubReconcilerTestCase struct {
 	CleanUp func(t *testing.T) error
 }
 
-// SubReconcilerTests represents a map of reconciler test cases. The map key is the name of each test case.
+// SubReconcilerTests represents a map of reconciler test cases. The map key is the name of each
+// test case.  Test cases are executed in random order.
 type SubReconcilerTests map[string]SubReconcilerTestCase
 
 // Run executes the test cases.
@@ -108,7 +109,8 @@ func (rt SubReconcilerTests) Run(t *testing.T, scheme *runtime.Scheme, factory S
 	rts.Run(t, scheme, factory)
 }
 
-// SubReconcilerTestSuite represents a list of subreconciler test cases.
+// SubReconcilerTestSuite represents a list of subreconciler test cases. The test cases are
+// executed in order.
 type SubReconcilerTestSuite []SubReconcilerTestCase
 
 // Run executes the test case.


### PR DESCRIPTION
(Sub)ReconcilerTests is a map based equivalent to the slice based
(Sub)ReconcilerTestSuite. The key of the map is the name of each test
case. This has a couple key advantages:
- the name of every test case is guaranteed unique by the compiler
- editor code folding will show the name and hide the detail

One downside is that the test cases will execute in random order as
iteration over a map is random in go.

Signed-off-by: Scott Andrews <andrewssc@vmware.com>