### PR TITLE
Seed the test tracker with given values

### DIFF
--- a/testing/config.go
+++ b/testing/config.go
@@ -44,6 +44,8 @@ type ExpectConfig struct {
 	// WithReactors installs each ReactionFunc into each fake clientset. ReactionFuncs intercept
 	// each call to the clientset providing the ability to mutate the resource or inject an error.
 	WithReactors []ReactionFunc
+	// GivenTracks provide a set of tracked resources to seed the tracker with
+	GivenTracks []TrackRequest
 
 	// side effects
 
@@ -97,7 +99,7 @@ func (c *ExpectConfig) init() {
 			events: []Event{},
 			scheme: c.Scheme,
 		}
-		c.tracker = createTracker()
+		c.tracker = createTracker(c.GivenTracks)
 		c.observedErrors = []string{}
 	})
 }

--- a/testing/config_test.go
+++ b/testing/config_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/vmware-labs/reconciler-runtime/internal/resources"
 	"github.com/vmware-labs/reconciler-runtime/reconcilers"
 	corev1 "k8s.io/api/core/v1"
@@ -160,6 +161,23 @@ func TestExpectConfig(t *testing.T) {
 			failedAssertions: []string{},
 		},
 
+		"given track": {
+			config: ExpectConfig{
+				GivenTracks: []TrackRequest{
+					NewTrackRequest(r2, r1, scheme),
+				},
+			},
+			operation: func(t *testing.T, ctx context.Context, c reconcilers.Config) {
+				actual := c.Tracker.Lookup(ctx, NewTrackRequest(r2, r1, scheme).Tracked)
+				expected := []types.NamespacedName{
+					{Namespace: r1.Namespace, Name: r1.Name},
+				}
+				if diff := cmp.Diff(expected, actual); diff != "" {
+					t.Errorf("unexpected value (-expected, +actual): %s", diff)
+				}
+			},
+			failedAssertions: []string{},
+		},
 		"expected track": {
 			config: ExpectConfig{
 				ExpectTracks: []TrackRequest{

--- a/testing/reconciler.go
+++ b/testing/reconciler.go
@@ -45,6 +45,8 @@ type ReconcilerTestCase struct {
 	GivenObjects []client.Object
 	// APIGivenObjects contains objects that are only available via an API reader instead of the normal cache
 	APIGivenObjects []client.Object
+	// GivenTracks provide a set of tracked resources to seed the tracker with
+	GivenTracks []TrackRequest
 
 	// side effects
 
@@ -153,6 +155,7 @@ func (tc *ReconcilerTestCase) Run(t *testing.T, scheme *runtime.Scheme, factory 
 		GivenObjects:            tc.GivenObjects,
 		APIGivenObjects:         tc.APIGivenObjects,
 		WithReactors:            tc.WithReactors,
+		GivenTracks:             tc.GivenTracks,
 		ExpectTracks:            tc.ExpectTracks,
 		ExpectEvents:            tc.ExpectEvents,
 		ExpectCreates:           tc.ExpectCreates,

--- a/testing/subreconciler.go
+++ b/testing/subreconciler.go
@@ -48,6 +48,8 @@ type SubReconcilerTestCase struct {
 	GivenObjects []client.Object
 	// APIGivenObjects contains objects that are only available via an API reader instead of the normal cache
 	APIGivenObjects []client.Object
+	// GivenTracks provide a set of tracked resources to seed the tracker with
+	GivenTracks []TrackRequest
 
 	// side effects
 
@@ -169,6 +171,7 @@ func (tc *SubReconcilerTestCase) Run(t *testing.T, scheme *runtime.Scheme, facto
 		GivenObjects:            append(tc.GivenObjects, tc.Resource),
 		APIGivenObjects:         append(tc.APIGivenObjects, tc.Resource),
 		WithReactors:            tc.WithReactors,
+		GivenTracks:             tc.GivenTracks,
 		ExpectTracks:            tc.ExpectTracks,
 		ExpectEvents:            tc.ExpectEvents,
 		ExpectCreates:           tc.ExpectCreates,

--- a/testing/tracker.go
+++ b/testing/tracker.go
@@ -54,8 +54,14 @@ func NewTrackRequest(t, b client.Object, scheme *runtime.Scheme) TrackRequest {
 
 const maxDuration = time.Duration(1<<63 - 1)
 
-func createTracker() *mockTracker {
-	return &mockTracker{Tracker: tracker.New(maxDuration), reqs: []TrackRequest{}}
+func createTracker(given []TrackRequest) *mockTracker {
+	t := &mockTracker{Tracker: tracker.New(maxDuration)}
+	for _, g := range given {
+		t.Track(context.TODO(), g.Tracked, g.Tracker)
+	}
+	// reset tracked requests
+	t.reqs = []TrackRequest{}
+	return t
 }
 
 type mockTracker struct {

--- a/testing/webhook.go
+++ b/testing/webhook.go
@@ -45,6 +45,8 @@ type AdmissionWebhookTestCase struct {
 	GivenObjects []client.Object
 	// APIGivenObjects contains objects that are only available via an API reader instead of the normal cache
 	APIGivenObjects []client.Object
+	// GivenTracks provide a set of tracked resources to seed the tracker with
+	GivenTracks []TrackRequest
 
 	// side effects
 
@@ -145,6 +147,7 @@ func (tc *AdmissionWebhookTestCase) Run(t *testing.T, scheme *runtime.Scheme, fa
 		GivenObjects:            tc.GivenObjects,
 		APIGivenObjects:         tc.APIGivenObjects,
 		WithReactors:            tc.WithReactors,
+		GivenTracks:             tc.GivenTracks,
 		ExpectTracks:            tc.ExpectTracks,
 		ExpectEvents:            tc.ExpectEvents,
 		ExpectCreates:           tc.ExpectCreates,

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -76,8 +76,7 @@ func New(lease time.Duration) Tracker {
 }
 
 type impl struct {
-	log logr.Logger
-	m   sync.Mutex
+	m sync.Mutex
 
 	// mapping maps from an object reference to the set of
 	// keys for objects watching it.


### PR DESCRIPTION
These seeded track requests are available to be queried within a test.
Previously it was necessary to call .Track() on the tracker to register
the request, but that also needed to be expressed as ExpectedTracks in
tests. Now the value can be set without triggering an expectation.

Signed-off-by: Scott Andrews <andrewssc@vmware.com>