### PR TITLE
Support Unstructured resources with ResourceReconciler

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ The resource reconciler is responsible for:
 - fetching the resource being reconciled
 - creating a stash to pass state between sub reconcilers
 - passing the resource to each sub reconciler in turn
-- initialize conditions on the status by calling status.InitializeConditions() if defined
-- normalizing the .status.conditions[].lastTransitionTime for status conditions that are metav1.Condition (the previous timestamp is preserved if the condition is otherwise unchanged)
-- reflects the observed generation on the status
+- initialize conditions on the status by calling status.InitializeConditions() if defined (not available for Unstructured resources)
+- normalizing the .status.conditions[].lastTransitionTime for status conditions that are metav1.Condition (the previous timestamp is preserved if the condition is otherwise unchanged) (not available for Unstructured resources)
+- reflects the observed generation on the status (not available for Unstructured resources)
 - updates the resource status if it was modified
 - logging the reconcilers activities
 - records events for mutations and errors

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/vmware-labs/reconciler-runtime
 go 1.19
 
 require (
-	dies.dev v0.6.0
+	dies.dev v0.6.1
 	github.com/evanphx/json-patch/v5 v5.6.0
 	github.com/go-logr/logr v1.2.3
 	github.com/google/go-cmp v0.5.8

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0Zeo
 cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohlUTyfDhBk=
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
-dies.dev v0.6.0 h1:favI/QTgjYtcuT1KoOHtZijDKuMh9h/kph30fGjglso=
-dies.dev v0.6.0/go.mod h1:ZO3Q4QFrmtHDvgG5iuGVqS4Vi4oBted6ifEK7pLstm0=
+dies.dev v0.6.1 h1:wRAdytEVZUVuSrg7viZ9tOUtPem/z0EFYlBlafTYdL0=
+dies.dev v0.6.1/go.mod h1:ZO3Q4QFrmtHDvgG5iuGVqS4Vi4oBted6ifEK7pLstm0=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=

--- a/hack/go.mod
+++ b/hack/go.mod
@@ -3,7 +3,7 @@ module github.com/vmware-labs/reconciler-runtime/hack
 go 1.19
 
 require (
-	dies.dev/diegen v0.6.0
+	dies.dev/diegen v0.6.1
 	sigs.k8s.io/controller-tools v0.9.2
 )
 

--- a/hack/go.sum
+++ b/hack/go.sum
@@ -36,8 +36,8 @@ cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0Zeo
 cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohlUTyfDhBk=
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
-dies.dev/diegen v0.6.0 h1:GBY/PvUUXJdHGCv6JiG/dCU2pTh19jnRELlEeHP4J6Y=
-dies.dev/diegen v0.6.0/go.mod h1:Sh3DR+p63PgMkU5mjqxSXyuPFcU5aLHzT7EIil2JAwk=
+dies.dev/diegen v0.6.1 h1:PC+T5KbPpXvsayyNG/DoCiwdZZyKSu3TkZnRfgX526Y=
+dies.dev/diegen v0.6.1/go.mod h1:Sh3DR+p63PgMkU5mjqxSXyuPFcU5aLHzT7EIil2JAwk=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=

--- a/internal/resources/dies/zz_generated.die.go
+++ b/internal/resources/dies/zz_generated.die.go
@@ -85,7 +85,7 @@ func (d *TestResourceDie) DieReleasePtr() *resources.TestResource {
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *TestResourceDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *TestResourceDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{
@@ -467,7 +467,7 @@ func (d *TestResourceEmptyStatusDie) DieReleasePtr() *resources.TestResourceEmpt
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *TestResourceEmptyStatusDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *TestResourceEmptyStatusDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{
@@ -729,7 +729,7 @@ func (d *TestResourceNoStatusDie) DieReleasePtr() *resources.TestResourceNoStatu
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *TestResourceNoStatusDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *TestResourceNoStatusDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{
@@ -892,7 +892,7 @@ func (d *TestResourceNilableStatusDie) DieReleasePtr() *resources.TestResourceNi
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *TestResourceNilableStatusDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *TestResourceNilableStatusDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{

--- a/reconcilers/reconcilers_test.go
+++ b/reconcilers/reconcilers_test.go
@@ -353,6 +353,88 @@ func TestResourceReconciler_NilableStatus(t *testing.T) {
 	})
 }
 
+func TestResourceReconciler_Unstructured(t *testing.T) {
+	testNamespace := "test-namespace"
+	testName := "test-resource"
+	testRequest := controllerruntime.Request{
+		NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testName},
+	}
+
+	scheme := runtime.NewScheme()
+	_ = resources.AddToScheme(scheme)
+
+	resource := dies.TestResourceBlank.
+		APIVersion(resources.GroupVersion.Identifier()).
+		Kind("TestResource").
+		MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+			d.Namespace(testNamespace)
+			d.Name(testName)
+			d.Generation(1)
+		}).
+		StatusDie(func(d *dies.TestResourceStatusDie) {
+			d.ConditionsDie(
+				diemetav1.ConditionBlank.Type(apis.ConditionReady).Status(metav1.ConditionUnknown).Reason("Initializing"),
+			)
+		})
+
+	rts := rtesting.ReconcilerTests{
+		"in sync status": {
+			Request: testRequest,
+			GivenObjects: []client.Object{
+				resource,
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return &reconcilers.SyncReconciler{
+						Sync: func(ctx context.Context, resource *unstructured.Unstructured) error {
+							return nil
+						},
+					}
+				},
+			},
+		},
+		"status update": {
+			Request: testRequest,
+			GivenObjects: []client.Object{
+				resource,
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler {
+					return &reconcilers.SyncReconciler{
+						Sync: func(ctx context.Context, resource *unstructured.Unstructured) error {
+							resource.Object["status"].(map[string]interface{})["fields"] = map[string]interface{}{
+								"Reconciler": "ran",
+							}
+							return nil
+						},
+					}
+				},
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "StatusUpdated", `Updated status`),
+			},
+			ExpectStatusUpdates: []client.Object{
+				resource.StatusDie(func(d *dies.TestResourceStatusDie) {
+					d.AddField("Reconciler", "ran")
+				}).DieReleaseUnstructured(),
+			},
+		},
+	}
+
+	rts.Run(t, scheme, func(t *testing.T, rtc *rtesting.ReconcilerTestCase, c reconcilers.Config) reconcile.Reconciler {
+		return &reconcilers.ResourceReconciler{
+			Type: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": resources.GroupVersion.Identifier(),
+					"kind":       "TestResource",
+				},
+			},
+			Reconciler: rtc.Metadata["SubReconciler"].(func(*testing.T, reconcilers.Config) reconcilers.SubReconciler)(t, c),
+			Config:     c,
+		}
+	})
+}
+
 func TestResourceReconciler(t *testing.T) {
 	testNamespace := "test-namespace"
 	testName := "test-resource"


### PR DESCRIPTION
Updating status based on SubReconciler mutations is now supported. Other
operations that require knowledge of the status are not supported, like:
- initializing conditions
- updating observed generation version
- normalizing lastTransitionTime condition timestamps

Resolves #287 

Signed-off-by: Scott Andrews <andrewssc@vmware.com>