### PR TITLE
Adapt to changes introduced in cmp 0.5.9

### DIFF
--- a/testing/config.go
+++ b/testing/config.go
@@ -359,31 +359,39 @@ func (c *ExpectConfig) compareActions(t *testing.T, actionName string, expectedA
 
 var (
 	IgnoreLastTransitionTime = cmp.FilterPath(func(p cmp.Path) bool {
-		return strings.HasSuffix(p.String(), "LastTransitionTime") ||
-			strings.HasSuffix(p.GoString(), `(map[string]interface {})["lastTransitionTime"]`)
+		str := p.String()
+		gostr := p.GoString()
+		return strings.HasSuffix(str, "LastTransitionTime") ||
+			strings.HasSuffix(gostr, `["lastTransitionTime"]`)
 	}, cmp.Ignore())
 	IgnoreTypeMeta = cmp.FilterPath(func(p cmp.Path) bool {
-		return strings.HasSuffix(p.String(), "TypeMeta.APIVersion") ||
-			strings.HasSuffix(p.GoString(), `(*unstructured.Unstructured).Object["apiVersion"]`) ||
-			strings.HasSuffix(p.GoString(), `{*unstructured.Unstructured}.Object["apiVersion"]`) ||
-			strings.HasSuffix(p.String(), "TypeMeta.Kind") ||
-			strings.HasSuffix(p.GoString(), `(*unstructured.Unstructured).Object["kind"]`) ||
-			strings.HasSuffix(p.GoString(), `{*unstructured.Unstructured}.Object["kind"]`)
+		str := p.String()
+		// only ignore for typed resources, compare TypeMeta values for unstructured
+		return strings.HasSuffix(str, "TypeMeta.APIVersion") ||
+			strings.HasSuffix(str, "TypeMeta.Kind")
 	}, cmp.Ignore())
 	IgnoreCreationTimestamp = cmp.FilterPath(func(p cmp.Path) bool {
-		return strings.HasSuffix(p.String(), "ObjectMeta.CreationTimestamp") ||
-			strings.HasSuffix(p.GoString(), `(*unstructured.Unstructured).Object["metadata"].(map[string]interface {})["creationTimestamp"]`) ||
-			strings.HasSuffix(p.GoString(), `{*unstructured.Unstructured}.Object["metadata"].(map[string]interface {})["creationTimestamp"]`)
+		str := p.String()
+		gostr := p.GoString()
+		return strings.HasSuffix(str, "ObjectMeta.CreationTimestamp") ||
+			strings.HasSuffix(gostr, `(*unstructured.Unstructured).Object["metadata"].(map[string]any)["creationTimestamp"]`) ||
+			strings.HasSuffix(gostr, `{*unstructured.Unstructured}.Object["metadata"].(map[string]any)["creationTimestamp"]`) ||
+			strings.HasSuffix(gostr, `(*unstructured.Unstructured).Object["metadata"].(map[string]interface {})["creationTimestamp"]`) ||
+			strings.HasSuffix(gostr, `{*unstructured.Unstructured}.Object["metadata"].(map[string]interface {})["creationTimestamp"]`)
 	}, cmp.Ignore())
 	IgnoreResourceVersion = cmp.FilterPath(func(p cmp.Path) bool {
-		return strings.HasSuffix(p.String(), "ObjectMeta.ResourceVersion") ||
-			strings.HasSuffix(p.GoString(), `(*unstructured.Unstructured).Object["metadata"].(map[string]interface {})["resourceVersion"]`) ||
-			strings.HasSuffix(p.GoString(), `{*unstructured.Unstructured}.Object["metadata"].(map[string]interface {})["resourceVersion"]`)
+		str := p.String()
+		gostr := p.GoString()
+		return strings.HasSuffix(str, "ObjectMeta.ResourceVersion") ||
+			strings.HasSuffix(gostr, `(*unstructured.Unstructured).Object["metadata"].(map[string]any)["resourceVersion"]`) ||
+			strings.HasSuffix(gostr, `{*unstructured.Unstructured}.Object["metadata"].(map[string]any)["resourceVersion"]`) ||
+			strings.HasSuffix(gostr, `(*unstructured.Unstructured).Object["metadata"].(map[string]interface {})["resourceVersion"]`) ||
+			strings.HasSuffix(gostr, `{*unstructured.Unstructured}.Object["metadata"].(map[string]interface {})["resourceVersion"]`)
 	}, cmp.Ignore())
 
 	statusSubresourceOnly = cmp.FilterPath(func(p cmp.Path) bool {
-		q := p.String()
-		return q != "" && !strings.HasPrefix(q, "Status")
+		str := p.String()
+		return str != "" && !strings.HasPrefix(str, "Status")
 	}, cmp.Ignore())
 
 	SafeDeployDiff = cmpopts.IgnoreUnexported(resource.Quantity{})


### PR DESCRIPTION
cmp in 0.5.9 subtly changed how the GoString method returns values for unstructured paths. `interface {}` is now returned using the alias `any`. We now handle both cases for our path matches and have added tests to detect future changes.

IgnoreTypeMeta no longer handles unstructured types. Setting the apiVersion and kind fields for unstructured is essential and should be compared, they are not meaningful for typed resources.

Signed-off-by: Scott Andrews <andrewssc@vmware.com>