### PR TITLE
Clear finalizer after managed resource is deleted

### DIFF
--- a/reconcilers/reconcilers.go
+++ b/reconcilers/reconcilers.go
@@ -603,7 +603,7 @@ func (r *AggregateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 	}
 
-	if !resource.GetDeletionTimestamp().IsZero() {
+	if resource.GetDeletionTimestamp() != nil {
 		// resource is being deleted, nothing to do
 		return ctrl.Result{}, nil
 	}
@@ -1847,13 +1847,16 @@ func (r *ResourceManager) Manage(ctx context.Context, resource, actual, desired 
 		r.mutationCache = cache.NewExpiring()
 	})
 
-	if actual == nil && desired == nil {
+	if (actual == nil || actual.GetCreationTimestamp().Time.IsZero()) && desired == nil {
+		if err := ClearFinalizer(ctx, resource, r.Finalizer); err != nil {
+			return nil, err
+		}
 		return nil, nil
 	}
 
 	// delete resource if no longer needed
 	if desired == nil {
-		if !actual.GetCreationTimestamp().Time.IsZero() {
+		if !actual.GetCreationTimestamp().Time.IsZero() && actual.GetDeletionTimestamp() == nil {
 			log.Info("deleting unwanted resource", "resource", namespaceName(actual))
 			if err := c.Delete(ctx, actual); err != nil {
 				log.Error(err, "unable to delete unwanted resource", "resource", namespaceName(actual))
@@ -1864,9 +1867,6 @@ func (r *ResourceManager) Manage(ctx context.Context, resource, actual, desired 
 			pc.Recorder.Eventf(resource, corev1.EventTypeNormal, "Deleted",
 				"Deleted %s %q", typeName(actual), actual.GetName())
 
-			if err := ClearFinalizer(ctx, resource, r.Finalizer); err != nil {
-				return nil, err
-			}
 		}
 		return nil, nil
 	}


### PR DESCRIPTION
Previously, the ResourceManager would try to clear a finalizer immediately after asking for the resource to be deleted. Now, we wait for the managed resource to fully terminate and then clear the finalizer.

This change also avoid attempting to delete a resource that is already terminating.

Resolves #303 