### PR TITLE
Allow custom assertions for stashed values

### DIFF
--- a/README.md
+++ b/README.md
@@ -738,7 +738,7 @@ To setup a Config for a test and make assertions that the expected behavior matc
 
 The stash allows passing arbitrary state between sub reconcilers within the scope of a single reconciler request. Values are stored on the context by [`StashValue`](https://pkg.go.dev/github.com/vmware-labs/reconciler-runtime/reconcilers#StashValue) and accessed via [`RetrieveValue`](https://pkg.go.dev/github.com/vmware-labs/reconciler-runtime/reconcilers#RetrieveValue).
 
-For testing, given stashed values can be defined in a [SubReconcilerTests](#subreconcilertests) with [`GivenStashedValues`](https://pkg.go.dev/github.com/vmware-labs/reconciler-runtime/testing#SubReconcilerTestCase.GivenStashedValues). Newly stashed or mutated values expectations are defined with [`ExpectStashedValues`](https://pkg.go.dev/github.com/vmware-labs/reconciler-runtime/testing#SubReconcilerTestCase.ExpectStashedValues).
+For testing, given stashed values can be defined in a [SubReconcilerTests](#subreconcilertests) with [`GivenStashedValues`](https://pkg.go.dev/github.com/vmware-labs/reconciler-runtime/testing#SubReconcilerTestCase.GivenStashedValues). Newly stashed or mutated values expectations are defined with [`ExpectStashedValues`](https://pkg.go.dev/github.com/vmware-labs/reconciler-runtime/testing#SubReconcilerTestCase.ExpectStashedValues). An optional, custom function for asserting stashed values can be provided via [`VerifyStashedValue`](https://pkg.go.dev/github.com/vmware-labs/reconciler-runtime/testing#SubReconcilerTestCase.VerifyStashedValue).
 
 **Example:**
 

--- a/testing/reconciler.go
+++ b/testing/reconciler.go
@@ -95,8 +95,11 @@ type ReconcilerTestCase struct {
 	CleanUp func(t *testing.T, ctx context.Context, tc *ReconcilerTestCase) error
 }
 
-// VerifyFunc is a verification function
+// VerifyFunc is a verification function for a reconciler's result
 type VerifyFunc func(t *testing.T, result controllerruntime.Result, err error)
+
+// VerifyStashedValueFunc is a verification function for the entries in the stash
+type VerifyStashedValueFunc func(t *testing.T, key reconcilers.StashKey, expected, actual interface{})
 
 // ReconcilerTests represents a map of reconciler test cases. The map key is the name of each test
 // case. Test cases are executed in random order.


### PR DESCRIPTION
Custom assertions for stashed values are helpful when they require bespoke verification. For example:

```go
	rtesting.SubReconcilerTestSuite{
		{
			// ...
			ExpectStashedValues: map[reconcilers.StashKey]interface{}{
				// ...
			},
			VerifyStashedValue: func(t *testing.T, key reconcilers.StashKey, expected, actual interface{}) {
				if diff := cmp.Diff(expected, actual, myCustomOpts); diff != "" {
					t.Errorf("Unexpected stash value %q (-expected, +actual): %s", key, diff)
				}
			},
		},
		// ...
	}   
```