### PR TITLE
Restore support in ChildReconciler for unstructured resources

### DIFF
--- a/reconcilers/reconcilers.go
+++ b/reconcilers/reconcilers.go
@@ -1121,7 +1121,7 @@ func (r *ChildReconciler[T, CT, CLT]) Reconcile(ctx context.Context, resource T)
 			// the created child from a previous turn may be slow to appear in the informer cache, but shouldn't appear
 			// on the reconciled resource as being not ready.
 			apierr := err.(apierrs.APIStatus)
-			conflicted := newEmpty(r.ChildType).(CT)
+			conflicted := r.ChildType.DeepCopyObject().(CT)
 			_ = c.APIReader.Get(ctx, types.NamespacedName{Namespace: resource.GetNamespace(), Name: apierr.Status().Details.Name}, conflicted)
 			if r.ourChild(resource, conflicted) {
 				// skip updating the reconciled resource's status, fail and try again
@@ -1145,8 +1145,8 @@ func (r *ChildReconciler[T, CT, CLT]) reconcile(ctx context.Context, resource T)
 	pc := RetrieveOriginalConfigOrDie(ctx)
 	c := RetrieveConfigOrDie(ctx)
 
-	actual := newEmpty(r.ChildType).(CT)
-	children := newEmpty(r.ChildListType).(CLT)
+	actual := r.ChildType.DeepCopyObject().(CT)
+	children := r.ChildListType.DeepCopyObject().(CLT)
 	if err := c.List(ctx, children, r.listOptions(ctx, resource)...); err != nil {
 		return nilCT, err
 	}

--- a/reconcilers/reconcilers_test.go
+++ b/reconcilers/reconcilers_test.go
@@ -2391,6 +2391,1006 @@ func TestChildReconciler(t *testing.T) {
 	})
 }
 
+func TestChildReconciler_Unstructured(t *testing.T) {
+	testNamespace := "test-namespace"
+	testName := "test-resource"
+	testFinalizer := "test.finalizer"
+
+	now := metav1.NewTime(time.Now().Truncate(time.Second))
+
+	scheme := runtime.NewScheme()
+	_ = resources.AddToScheme(scheme)
+	_ = clientgoscheme.AddToScheme(scheme)
+
+	resource := dies.TestResourceBlank.
+		APIVersion("testing.reconciler.runtime/v1").
+		Kind("TestResource").
+		MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+			d.Namespace(testNamespace)
+			d.Name(testName)
+		}).
+		StatusDie(func(d *dies.TestResourceStatusDie) {
+			d.ConditionsDie(
+				diemetav1.ConditionBlank.Type(apis.ConditionReady).Status(metav1.ConditionUnknown).Reason("Initializing"),
+			)
+		})
+	resourceReady := resource.
+		StatusDie(func(d *dies.TestResourceStatusDie) {
+			d.ConditionsDie(
+				diemetav1.ConditionBlank.Type(apis.ConditionReady).Status(metav1.ConditionTrue).Reason("Ready"),
+			)
+		})
+
+	configMapCreate := diecorev1.ConfigMapBlank.
+		APIVersion("v1").
+		Kind("ConfigMap").
+		MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+			d.Namespace(testNamespace)
+			d.Name(testName)
+			d.ControlledBy(resource, scheme)
+		}).
+		AddData("foo", "bar")
+	configMapGiven := configMapCreate.
+		MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+		})
+
+	defaultChildReconciler := func(c reconcilers.Config) *reconcilers.ChildReconciler[*unstructured.Unstructured, *unstructured.Unstructured, *unstructured.UnstructuredList] {
+		return &reconcilers.ChildReconciler[*unstructured.Unstructured, *unstructured.Unstructured, *unstructured.UnstructuredList]{
+			ChildType: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+				},
+			},
+			ChildListType: &unstructured.UnstructuredList{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "ConfigMapList",
+				},
+			},
+			DesiredChild: func(ctx context.Context, parent *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+				fields, ok, _ := unstructured.NestedMap(parent.Object, "spec", "fields")
+				if !ok || len(fields) == 0 {
+					return nil, nil
+				}
+
+				child := &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "v1",
+						"kind":       "ConfigMap",
+						"metadata": map[string]interface{}{
+							"namespace": parent.GetNamespace(),
+							"name":      parent.GetName(),
+						},
+						"data": map[string]interface{}{},
+					},
+				}
+				for k, v := range fields {
+					unstructured.SetNestedField(child.Object, v, "data", k)
+				}
+
+				return child, nil
+			},
+			MergeBeforeUpdate: func(current, desired *unstructured.Unstructured) {
+				current.Object["data"] = desired.Object["data"]
+			},
+			ReflectChildStatusOnParent: func(parent *unstructured.Unstructured, child *unstructured.Unstructured, err error) {
+				if err != nil {
+					if apierrs.IsAlreadyExists(err) {
+						name := err.(apierrs.APIStatus).Status().Details.Name
+						readyCond := map[string]interface{}{
+							"type":    "Ready",
+							"status":  "False",
+							"reason":  "NameConflict",
+							"message": fmt.Sprintf("%q already exists", name),
+						}
+						unstructured.SetNestedSlice(parent.Object, []interface{}{readyCond}, "status", "conditions")
+					}
+					return
+				}
+				if child == nil {
+					unstructured.RemoveNestedField(parent.Object, "status", "fields")
+					readyCond := map[string]interface{}{
+						"type":    "Ready",
+						"status":  "True",
+						"reason":  "Ready",
+						"message": "",
+					}
+					unstructured.SetNestedSlice(parent.Object, []interface{}{readyCond}, "status", "conditions")
+					return
+				}
+				unstructured.SetNestedMap(parent.Object, map[string]interface{}{}, "status", "fields")
+				for k, v := range child.Object["data"].(map[string]interface{}) {
+					unstructured.SetNestedField(parent.Object, v, "status", "fields", k)
+				}
+				readyCond := map[string]interface{}{
+					"type":    "Ready",
+					"status":  "True",
+					"reason":  "Ready",
+					"message": "",
+				}
+				unstructured.SetNestedSlice(parent.Object, []interface{}{readyCond}, "status", "conditions")
+			},
+		}
+	}
+
+	rts := rtesting.SubReconcilerTests[*unstructured.Unstructured]{
+		"preserve no child": {
+			Resource: resourceReady.DieReleaseUnstructured(),
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler[*unstructured.Unstructured] {
+					return defaultChildReconciler(c)
+				},
+			},
+		},
+		"child is in sync": {
+			Resource: resourceReady.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
+				}).
+				StatusDie(func(d *dies.TestResourceStatusDie) {
+					d.AddField("foo", "bar")
+				}).
+				DieReleaseUnstructured(),
+			GivenObjects: []client.Object{
+				configMapGiven,
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler[*unstructured.Unstructured] {
+					return defaultChildReconciler(c)
+				},
+			},
+		},
+		"child is in sync, in a different namespace": {
+			Resource: resourceReady.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
+				}).
+				StatusDie(func(d *dies.TestResourceStatusDie) {
+					d.AddField("foo", "bar")
+				}).
+				DieReleaseUnstructured(),
+			GivenObjects: []client.Object{
+				configMapGiven.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.Namespace("other-ns")
+					}),
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler[*unstructured.Unstructured] {
+					r := defaultChildReconciler(c)
+					r.ListOptions = func(ctx context.Context, parent *unstructured.Unstructured) []client.ListOption {
+						return []client.ListOption{
+							client.InNamespace("other-ns"),
+						}
+					}
+					return r
+				},
+			},
+		},
+		"create child": {
+			Resource: resource.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
+				}).
+				DieReleaseUnstructured(),
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler[*unstructured.Unstructured] {
+					return defaultChildReconciler(c)
+				},
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Created",
+					`Created ConfigMap %q`, testName),
+			},
+			ExpectResource: resourceReady.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
+				}).
+				StatusDie(func(d *dies.TestResourceStatusDie) {
+					d.AddField("foo", "bar")
+				}).
+				DieReleaseUnstructured(),
+			ExpectCreates: []client.Object{
+				configMapCreate.DieReleaseUnstructured(),
+			},
+		},
+		"create child with finalizer": {
+			Resource: resource.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
+				}).
+				DieReleaseUnstructured(),
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler[*unstructured.Unstructured] {
+					r := defaultChildReconciler(c)
+					r.Finalizer = testFinalizer
+					r.SkipOwnerReference = true
+					r.OurChild = func(parent *unstructured.Unstructured, child *unstructured.Unstructured) bool { return true }
+					return r
+				},
+			},
+			ExpectTracks: []rtesting.TrackRequest{
+				rtesting.NewTrackRequest(configMapCreate, resource, scheme),
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "FinalizerPatched",
+					`Patched finalizer %q`, testFinalizer),
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Created",
+					`Created ConfigMap %q`, testName),
+			},
+			ExpectResource: resourceReady.
+				MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+					d.Finalizers(testFinalizer)
+					d.ResourceVersion("1000")
+				}).
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
+				}).
+				StatusDie(func(d *dies.TestResourceStatusDie) {
+					d.AddField("foo", "bar")
+				}).
+				DieReleaseUnstructured(),
+			ExpectCreates: []client.Object{
+				configMapCreate.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.OwnerReferences()
+					}).
+					DieReleaseUnstructured(),
+			},
+			ExpectPatches: []rtesting.PatchRef{
+				{
+					Group:     "testing.reconciler.runtime",
+					Kind:      "TestResource",
+					Namespace: testNamespace,
+					Name:      testName,
+					PatchType: types.MergePatchType,
+					Patch:     []byte(`{"metadata":{"finalizers":["test.finalizer"],"resourceVersion":"999"}}`),
+				},
+			},
+		},
+		"update child": {
+			Resource: resourceReady.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
+					d.AddField("new", "field")
+				}).
+				StatusDie(func(d *dies.TestResourceStatusDie) {
+					d.AddField("foo", "bar")
+				}).
+				DieReleaseUnstructured(),
+			GivenObjects: []client.Object{
+				configMapGiven,
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler[*unstructured.Unstructured] {
+					return defaultChildReconciler(c)
+				},
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Updated",
+					`Updated ConfigMap %q`, testName),
+			},
+			ExpectResource: resourceReady.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
+					d.AddField("new", "field")
+				}).
+				StatusDie(func(d *dies.TestResourceStatusDie) {
+					d.AddField("foo", "bar")
+					d.AddField("new", "field")
+				}).
+				DieReleaseUnstructured(),
+			ExpectUpdates: []client.Object{
+				configMapGiven.
+					AddData("new", "field").
+					DieReleaseUnstructured(),
+			},
+		},
+		"update child, preserve finalizers": {
+			Resource: resourceReady.
+				MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+					d.Finalizers(testFinalizer, "some.other.finalizer")
+				}).
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
+					d.AddField("new", "field")
+				}).
+				StatusDie(func(d *dies.TestResourceStatusDie) {
+					d.AddField("foo", "bar")
+				}).
+				DieReleaseUnstructured(),
+			GivenObjects: []client.Object{
+				configMapGiven.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.OwnerReferences()
+					}),
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler[*unstructured.Unstructured] {
+					r := defaultChildReconciler(c)
+					r.Finalizer = testFinalizer
+					r.SkipOwnerReference = true
+					r.OurChild = func(parent *unstructured.Unstructured, child *unstructured.Unstructured) bool { return true }
+					return r
+				},
+			},
+			ExpectTracks: []rtesting.TrackRequest{
+				rtesting.NewTrackRequest(configMapGiven, resource, scheme),
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Updated",
+					`Updated ConfigMap %q`, testName),
+			},
+			ExpectResource: resourceReady.
+				MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+					d.Finalizers(testFinalizer, "some.other.finalizer")
+				}).
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
+					d.AddField("new", "field")
+				}).
+				StatusDie(func(d *dies.TestResourceStatusDie) {
+					d.AddField("foo", "bar")
+					d.AddField("new", "field")
+				}).
+				DieReleaseUnstructured(),
+			ExpectUpdates: []client.Object{
+				configMapGiven.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.OwnerReferences()
+					}).
+					AddData("new", "field").
+					DieReleaseUnstructured(),
+			},
+		},
+		"update child, restoring missing finalizer": {
+			Resource: resourceReady.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
+					d.AddField("new", "field")
+				}).
+				StatusDie(func(d *dies.TestResourceStatusDie) {
+					d.AddField("foo", "bar")
+				}).
+				DieReleaseUnstructured(),
+			GivenObjects: []client.Object{
+				configMapGiven.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.OwnerReferences()
+					}),
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler[*unstructured.Unstructured] {
+					r := defaultChildReconciler(c)
+					r.Finalizer = testFinalizer
+					r.SkipOwnerReference = true
+					r.OurChild = func(parent *unstructured.Unstructured, child *unstructured.Unstructured) bool { return true }
+					return r
+				},
+			},
+			ExpectTracks: []rtesting.TrackRequest{
+				rtesting.NewTrackRequest(configMapGiven, resource, scheme),
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "FinalizerPatched",
+					`Patched finalizer %q`, testFinalizer),
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Updated",
+					`Updated ConfigMap %q`, testName),
+			},
+			ExpectResource: resourceReady.
+				MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+					d.Finalizers(testFinalizer)
+					d.ResourceVersion("1000")
+				}).
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
+					d.AddField("new", "field")
+				}).
+				StatusDie(func(d *dies.TestResourceStatusDie) {
+					d.AddField("foo", "bar")
+					d.AddField("new", "field")
+				}).
+				DieReleaseUnstructured(),
+			ExpectUpdates: []client.Object{
+				configMapGiven.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.OwnerReferences()
+					}).
+					AddData("new", "field").
+					DieReleaseUnstructured(),
+			},
+			ExpectPatches: []rtesting.PatchRef{
+				{
+					Group:     "testing.reconciler.runtime",
+					Kind:      "TestResource",
+					Namespace: testNamespace,
+					Name:      testName,
+					PatchType: types.MergePatchType,
+					Patch:     []byte(`{"metadata":{"finalizers":["test.finalizer"],"resourceVersion":"999"}}`),
+				},
+			},
+		},
+		"delete child": {
+			Resource: resourceReady.DieReleaseUnstructured(),
+			GivenObjects: []client.Object{
+				configMapGiven,
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler[*unstructured.Unstructured] {
+					return defaultChildReconciler(c)
+				},
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Deleted",
+					`Deleted ConfigMap %q`, testName),
+			},
+			ExpectDeletes: []rtesting.DeleteRef{
+				rtesting.NewDeleteRefFromObject(configMapGiven, scheme),
+			},
+		},
+		"delete child, preserve finalizers": {
+			Resource: resourceReady.
+				MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+					d.Finalizers(testFinalizer, "some.other.finalizer")
+				}).
+				DieReleaseUnstructured(),
+			GivenObjects: []client.Object{
+				configMapGiven.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.OwnerReferences()
+					}),
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler[*unstructured.Unstructured] {
+					r := defaultChildReconciler(c)
+					r.Finalizer = testFinalizer
+					r.SkipOwnerReference = true
+					r.OurChild = func(parent *unstructured.Unstructured, child *unstructured.Unstructured) bool { return true }
+					return r
+				},
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Deleted",
+					`Deleted ConfigMap %q`, testName),
+			},
+			ExpectDeletes: []rtesting.DeleteRef{
+				rtesting.NewDeleteRefFromObject(configMapGiven, scheme),
+			},
+		},
+		"ignore extraneous children": {
+			Resource: resourceReady.DieReleaseUnstructured(),
+			GivenObjects: []client.Object{
+				configMapGiven,
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler[*unstructured.Unstructured] {
+					r := defaultChildReconciler(c)
+					r.OurChild = func(parent *unstructured.Unstructured, child *unstructured.Unstructured) bool {
+						return false
+					}
+					return r
+				},
+			},
+		},
+		"delete duplicate children": {
+			Resource: resource.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
+				}).
+				DieReleaseUnstructured(),
+			GivenObjects: []client.Object{
+				configMapGiven.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.Name("extra-child-1")
+					}),
+				configMapGiven.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.Name("extra-child-2")
+					}),
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler[*unstructured.Unstructured] {
+					return defaultChildReconciler(c)
+				},
+			},
+			ExpectResource: resourceReady.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
+				}).
+				StatusDie(func(d *dies.TestResourceStatusDie) {
+					d.AddField("foo", "bar")
+				}).
+				DieReleaseUnstructured(),
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Deleted",
+					`Deleted ConfigMap %q`, "extra-child-1"),
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Deleted",
+					`Deleted ConfigMap %q`, "extra-child-2"),
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Created",
+					`Created ConfigMap %q`, testName),
+			},
+			ExpectDeletes: []rtesting.DeleteRef{
+				{Group: "", Kind: "ConfigMap", Namespace: testNamespace, Name: "extra-child-1"},
+				{Group: "", Kind: "ConfigMap", Namespace: testNamespace, Name: "extra-child-2"},
+			},
+			ExpectCreates: []client.Object{
+				configMapCreate.DieReleaseUnstructured(),
+			},
+		},
+		"delete child during finalization": {
+			Resource: resourceReady.
+				MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+					d.DeletionTimestamp(&now)
+					d.Finalizers(testFinalizer)
+				}).
+				DieReleaseUnstructured(),
+			GivenObjects: []client.Object{
+				configMapGiven.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.OwnerReferences()
+					}),
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler[*unstructured.Unstructured] {
+					r := defaultChildReconciler(c)
+					r.Finalizer = testFinalizer
+					r.SkipOwnerReference = true
+					r.OurChild = func(parent *unstructured.Unstructured, child *unstructured.Unstructured) bool { return true }
+					return r
+				},
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Deleted",
+					`Deleted ConfigMap %q`, testName),
+			},
+			ExpectDeletes: []rtesting.DeleteRef{
+				rtesting.NewDeleteRefFromObject(configMapGiven, scheme),
+			},
+		},
+		"clear finalizer after child fully deleted": {
+			Resource: resourceReady.
+				MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+					d.DeletionTimestamp(&now)
+					d.Finalizers(testFinalizer)
+				}).
+				DieReleaseUnstructured(),
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler[*unstructured.Unstructured] {
+					r := defaultChildReconciler(c)
+					r.Finalizer = testFinalizer
+					r.SkipOwnerReference = true
+					r.OurChild = func(parent *unstructured.Unstructured, child *unstructured.Unstructured) bool { return true }
+					return r
+				},
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "FinalizerPatched",
+					`Patched finalizer %q`, testFinalizer),
+			},
+			ExpectResource: resourceReady.
+				MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+					d.DeletionTimestamp(&now)
+					d.Finalizers()
+					d.ResourceVersion("1000")
+				}).
+				DieReleaseUnstructured(),
+			ExpectPatches: []rtesting.PatchRef{
+				{
+					Group:     "testing.reconciler.runtime",
+					Kind:      "TestResource",
+					Namespace: testNamespace,
+					Name:      testName,
+					PatchType: types.MergePatchType,
+					Patch:     []byte(`{"metadata":{"finalizers":[],"resourceVersion":"999"}}`),
+				},
+			},
+		},
+		"preserve finalizer for terminating child": {
+			Resource: resourceReady.
+				MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+					d.DeletionTimestamp(&now)
+					d.Finalizers(testFinalizer)
+				}).
+				DieReleaseUnstructured(),
+			GivenObjects: []client.Object{
+				configMapGiven.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.OwnerReferences()
+						d.DeletionTimestamp(&now)
+					}),
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler[*unstructured.Unstructured] {
+					r := defaultChildReconciler(c)
+					r.Finalizer = testFinalizer
+					r.SkipOwnerReference = true
+					r.OurChild = func(parent *unstructured.Unstructured, child *unstructured.Unstructured) bool { return true }
+					return r
+				},
+			},
+		},
+		"child name collision": {
+			Resource: resourceReady.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
+				}).
+				DieReleaseUnstructured(),
+			WithReactors: []rtesting.ReactionFunc{
+				rtesting.InduceFailure("create", "ConfigMap", rtesting.InduceFailureOpts{
+					Error: apierrs.NewAlreadyExists(schema.GroupResource{}, testName),
+				}),
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler[*unstructured.Unstructured] {
+					return defaultChildReconciler(c)
+				},
+			},
+			ExpectResource: resourceReady.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
+				}).
+				StatusDie(func(d *dies.TestResourceStatusDie) {
+					d.ConditionsDie(
+						diemetav1.ConditionBlank.Type(apis.ConditionReady).Status(metav1.ConditionFalse).
+							Reason("NameConflict").Message(`"test-resource" already exists`),
+					)
+				}).
+				DieReleaseUnstructured(),
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeWarning, "CreationFailed",
+					"Failed to create ConfigMap %q:  %q already exists", testName, testName),
+			},
+			ExpectCreates: []client.Object{
+				configMapCreate.DieReleaseUnstructured(),
+			},
+		},
+		"child name collision, stale informer cache": {
+			Resource: resourceReady.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
+				}).
+				DieReleaseUnstructured(),
+			APIGivenObjects: []client.Object{
+				configMapGiven,
+			},
+			WithReactors: []rtesting.ReactionFunc{
+				rtesting.InduceFailure("create", "ConfigMap", rtesting.InduceFailureOpts{
+					Error: apierrs.NewAlreadyExists(schema.GroupResource{}, testName),
+				}),
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler[*unstructured.Unstructured] {
+					return defaultChildReconciler(c)
+				},
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeWarning, "CreationFailed",
+					"Failed to create ConfigMap %q:  %q already exists", testName, testName),
+			},
+			ExpectCreates: []client.Object{
+				configMapCreate.DieReleaseUnstructured(),
+			},
+			ShouldErr: true,
+		},
+		"preserve immutable fields": {
+			Resource: resourceReady.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
+				}).
+				StatusDie(func(d *dies.TestResourceStatusDie) {
+					d.AddField("foo", "bar")
+					d.AddField("immutable", "field")
+				}).
+				DieReleaseUnstructured(),
+			GivenObjects: []client.Object{
+				configMapGiven.
+					AddData("immutable", "field"),
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler[*unstructured.Unstructured] {
+					r := defaultChildReconciler(c)
+					r.HarmonizeImmutableFields = func(current, desired *unstructured.Unstructured) {
+						immutable, _, _ := unstructured.NestedString(current.Object, "data", "immutable")
+						unstructured.SetNestedField(desired.Object, immutable, "data", "immutable")
+					}
+					return r
+				},
+			},
+		},
+		"status only reconcile": {
+			Resource: resource.DieReleaseUnstructured(),
+			GivenObjects: []client.Object{
+				configMapGiven,
+			},
+			ExpectResource: resourceReady.
+				StatusDie(func(d *dies.TestResourceStatusDie) {
+					d.AddField("foo", "bar")
+				}).
+				DieReleaseUnstructured(),
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler[*unstructured.Unstructured] {
+					r := defaultChildReconciler(c)
+					r.DesiredChild = func(ctx context.Context, parent *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+						return nil, reconcilers.OnlyReconcileChildStatus
+					}
+					return r
+				},
+			},
+		},
+		"sanitize child before logging": {
+			Resource: resource.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
+				}).
+				DieReleaseUnstructured(),
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler[*unstructured.Unstructured] {
+					r := defaultChildReconciler(c)
+					r.Sanitize = func(child *unstructured.Unstructured) interface{} {
+						return child.GetName()
+					}
+					return r
+				},
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Created",
+					`Created ConfigMap %q`, testName),
+			},
+			ExpectResource: resourceReady.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
+				}).
+				StatusDie(func(d *dies.TestResourceStatusDie) {
+					d.AddField("foo", "bar")
+				}).
+				DieReleaseUnstructured(),
+			ExpectCreates: []client.Object{
+				configMapCreate.DieReleaseUnstructured(),
+			},
+		},
+		"sanitize is mutation safe": {
+			Resource: resource.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
+				}).
+				DieReleaseUnstructured(),
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler[*unstructured.Unstructured] {
+					r := defaultChildReconciler(c)
+					r.Sanitize = func(child *unstructured.Unstructured) interface{} {
+						unstructured.SetNestedField(child.Object, "me", "data", "ignore")
+						return child
+					}
+					return r
+				},
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Created",
+					`Created ConfigMap %q`, testName),
+			},
+			ExpectResource: resourceReady.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
+				}).
+				StatusDie(func(d *dies.TestResourceStatusDie) {
+					d.AddField("foo", "bar")
+				}).
+				DieReleaseUnstructured(),
+			ExpectCreates: []client.Object{
+				configMapCreate.DieReleaseUnstructured(),
+			},
+		},
+		"error listing children": {
+			Resource: resourceReady.DieReleaseUnstructured(),
+			WithReactors: []rtesting.ReactionFunc{
+				rtesting.InduceFailure("list", "ConfigMapList"),
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler[*unstructured.Unstructured] {
+					return defaultChildReconciler(c)
+				},
+			},
+			ShouldErr: true,
+		},
+		"error creating child": {
+			Resource: resource.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
+				}).
+				DieReleaseUnstructured(),
+			WithReactors: []rtesting.ReactionFunc{
+				rtesting.InduceFailure("create", "ConfigMap"),
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler[*unstructured.Unstructured] {
+					return defaultChildReconciler(c)
+				},
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeWarning, "CreationFailed",
+					`Failed to create ConfigMap %q: inducing failure for create ConfigMap`, testName),
+			},
+			ExpectCreates: []client.Object{
+				configMapCreate.DieReleaseUnstructured(),
+			},
+			ShouldErr: true,
+		},
+		"error adding finalizer": {
+			Resource: resource.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
+				}).
+				DieReleaseUnstructured(),
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler[*unstructured.Unstructured] {
+					r := defaultChildReconciler(c)
+					r.Finalizer = testFinalizer
+					r.SkipOwnerReference = true
+					r.OurChild = func(parent *unstructured.Unstructured, child *unstructured.Unstructured) bool { return true }
+					return r
+				},
+			},
+			WithReactors: []rtesting.ReactionFunc{
+				rtesting.InduceFailure("patch", "TestResource"),
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeWarning, "FinalizerPatchFailed",
+					`Failed to patch finalizer %q: inducing failure for patch TestResource`, testFinalizer),
+			},
+			ExpectPatches: []rtesting.PatchRef{
+				{
+					Group:     "testing.reconciler.runtime",
+					Kind:      "TestResource",
+					Namespace: testNamespace,
+					Name:      testName,
+					PatchType: types.MergePatchType,
+					Patch:     []byte(`{"metadata":{"finalizers":["test.finalizer"],"resourceVersion":"999"}}`),
+				},
+			},
+			ShouldErr: true,
+		},
+		"error clearing finalizer": {
+			Resource: resourceReady.
+				MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+					d.Finalizers(testFinalizer)
+				}).
+				DieReleaseUnstructured(),
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler[*unstructured.Unstructured] {
+					r := defaultChildReconciler(c)
+					r.Finalizer = testFinalizer
+					r.SkipOwnerReference = true
+					r.OurChild = func(parent *unstructured.Unstructured, child *unstructured.Unstructured) bool { return true }
+					return r
+				},
+			},
+			WithReactors: []rtesting.ReactionFunc{
+				rtesting.InduceFailure("patch", "TestResource"),
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeWarning, "FinalizerPatchFailed",
+					`Failed to patch finalizer %q: inducing failure for patch TestResource`, testFinalizer),
+			},
+			ExpectPatches: []rtesting.PatchRef{
+				{
+					Group:     "testing.reconciler.runtime",
+					Kind:      "TestResource",
+					Namespace: testNamespace,
+					Name:      testName,
+					PatchType: types.MergePatchType,
+					Patch:     []byte(`{"metadata":{"finalizers":[],"resourceVersion":"999"}}`),
+				},
+			},
+			ShouldErr: true,
+		},
+		"error updating child": {
+			Resource: resourceReady.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
+					d.AddField("new", "field")
+				}).
+				StatusDie(func(d *dies.TestResourceStatusDie) {
+					d.AddField("foo", "bar")
+				}).
+				DieReleaseUnstructured(),
+			GivenObjects: []client.Object{
+				configMapGiven,
+			},
+			WithReactors: []rtesting.ReactionFunc{
+				rtesting.InduceFailure("update", "ConfigMap"),
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler[*unstructured.Unstructured] {
+					return defaultChildReconciler(c)
+				},
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeWarning, "UpdateFailed",
+					`Failed to update ConfigMap %q: inducing failure for update ConfigMap`, testName),
+			},
+			ExpectUpdates: []client.Object{
+				configMapGiven.
+					AddData("new", "field").
+					DieReleaseUnstructured(),
+			},
+			ShouldErr: true,
+		},
+		"error deleting child": {
+			Resource: resourceReady.DieReleaseUnstructured(),
+			GivenObjects: []client.Object{
+				configMapGiven,
+			},
+			WithReactors: []rtesting.ReactionFunc{
+				rtesting.InduceFailure("delete", "ConfigMap"),
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler[*unstructured.Unstructured] {
+					return defaultChildReconciler(c)
+				},
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeWarning, "DeleteFailed",
+					`Failed to delete ConfigMap %q: inducing failure for delete ConfigMap`, testName),
+			},
+			ExpectDeletes: []rtesting.DeleteRef{
+				rtesting.NewDeleteRefFromObject(configMapGiven, scheme),
+			},
+			ShouldErr: true,
+		},
+		"error deleting duplicate children": {
+			Resource: resource.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("foo", "bar")
+				}).
+				DieReleaseUnstructured(),
+			GivenObjects: []client.Object{
+				configMapGiven.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.Name("extra-child-1")
+					}),
+				configMapGiven.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.Name("extra-child-2")
+					}),
+			},
+			WithReactors: []rtesting.ReactionFunc{
+				rtesting.InduceFailure("delete", "ConfigMap"),
+			},
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler[*unstructured.Unstructured] {
+					return defaultChildReconciler(c)
+				},
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeWarning, "DeleteFailed",
+					`Failed to delete ConfigMap %q: inducing failure for delete ConfigMap`, "extra-child-1"),
+			},
+			ExpectDeletes: []rtesting.DeleteRef{
+				{Group: "", Kind: "ConfigMap", Namespace: testNamespace, Name: "extra-child-1"},
+			},
+			ShouldErr: true,
+		},
+		"error creating desired child": {
+			Resource: resource.DieReleaseUnstructured(),
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler[*unstructured.Unstructured] {
+					r := defaultChildReconciler(c)
+					r.DesiredChild = func(ctx context.Context, parent *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+						return nil, fmt.Errorf("test error")
+					}
+					return r
+				},
+			},
+			ShouldErr: true,
+		},
+	}
+
+	rts.Run(t, scheme, func(t *testing.T, rtc *rtesting.SubReconcilerTestCase[*unstructured.Unstructured], c reconcilers.Config) reconcilers.SubReconciler[*unstructured.Unstructured] {
+		return rtc.Metadata["SubReconciler"].(func(*testing.T, reconcilers.Config) reconcilers.SubReconciler[*unstructured.Unstructured])(t, c)
+	})
+}
+
 func TestSequence(t *testing.T) {
 	testNamespace := "test-namespace"
 	testName := "test-resource"

--- a/testing/config.go
+++ b/testing/config.go
@@ -173,7 +173,7 @@ func (c *ExpectConfig) AssertClientCreateExpectations(t *testing.T) {
 	}
 	c.init()
 
-	c.compareActions(t, "create", c.ExpectCreates, c.client.CreateActions, IgnoreLastTransitionTime, SafeDeployDiff, IgnoreTypeMeta, IgnoreResourceVersion, cmpopts.EquateEmpty())
+	c.compareActions(t, "create", c.ExpectCreates, c.client.CreateActions, IgnoreLastTransitionTime, SafeDeployDiff, IgnoreTypeMeta, IgnoreCreationTimestamp, IgnoreResourceVersion, cmpopts.EquateEmpty())
 }
 
 // AssertClientUpdateExpectations asserts observed reconciler client update behavior matches the expected client update behavior


### PR DESCRIPTION
Adding a duplicate test suite for ChildReconciler using unstructured parent and child resources.