### PR TITLE
Forces subpaths to be created.

### DIFF
--- a/reconcilers/patch.go
+++ b/reconcilers/patch.go
@@ -58,7 +58,7 @@ func (p *Patch) Apply(rebase client.Object) error {
 	if err != nil {
 		return err
 	}
-	patchedBytes, err := merge.Apply(rebaseBytes)
+	patchedBytes, err := merge.ApplyWithOptions(rebaseBytes, &jsonmergepatch.ApplyOptions{EnsurePathExistsOnAdd: true})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I do not know what side effects this has on other reconcilers, but it makes my cast from unstructured work as I would expect