### PR TITLE
Respect desired child's controlling owner reference

### DIFF
--- a/reconcilers/reconcilers.go
+++ b/reconcilers/reconcilers.go
@@ -1224,7 +1224,7 @@ func (r *ChildReconciler[T, CT, CLT]) reconcile(ctx context.Context, resource T)
 		return nilCT, err
 	}
 	if !internal.IsNil(desired) {
-		if !r.SkipOwnerReference {
+		if !r.SkipOwnerReference && metav1.GetControllerOfNoCopy(desired) == nil {
 			if err := ctrl.SetControllerReference(resource, desired, c.Scheme()); err != nil {
 				return nilCT, err
 			}


### PR DESCRIPTION
When a desired child resource has a controlling owner reference defined, we now respect that value and no longer attempt to redefine the reference.

This can be useful when one of the default values needs to have a different value, or the parent resource type is not defined in the scheme.