### PR TITLE
Flow control SubReconcilers

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Within an existing Kubebuilder or controller-runtime project, reconciler-runtime
 	- [Higher-order Reconcilers](#higher-order-reconcilers)
 		- [CastResource](#castresource)
 		- [Sequence](#sequence)
+		- [IfThen](#ifthen)
+		- [While](#while)
+		- [TryCatch](#trycatch)
+		- [OverrideSetup](#overridesetup)
 		- [WithConfig](#withconfig)
 		- [WithFinalizer](#withfinalizer)
 	- [AdmissionWebhookAdapter](#admissionwebhookadapter)
@@ -452,6 +456,108 @@ func FunctionReconciler(c reconcilers.Config) *reconcilers.ResourceReconciler[*b
 }
 ```
 [full source](https://github.com/projectriff/system/blob/4c3b75327bf99cc37b57ba14df4c65d21dc79d28/pkg/controllers/build/function_reconciler.go#L39-L51)
+
+#### IfThen
+
+An [`IfThen`](https://pkg.go.dev/github.com/vmware-labs/reconciler-runtime/reconcilers#IfThen) branches execution of the current reconcile request based on a condition. The false `Else` branch is optional and ignored if not defined.
+
+**Example:**
+
+An IfThen can be used to gate a capability of the reconciler only for a resource that opts-in to the behavior. 
+
+```go
+func GatedReconciler() *reconcilers.SubReconciler[*buildv1alpha1.Function] {
+	return &reconcilers.IfThen[*buildv1alpha1.Function]{
+		If: func(ctx context.Context, resource *buildv1alpha1.Function) bool {
+			return resource.Labels["capability-gate.example/enabled"] == "true"
+		}
+		Then: reconcilers.Sequence[*buildv1alpha1.Function]{
+			// use the gated feature
+		},
+	}
+}
+```
+
+#### While
+
+A [`While`](https://pkg.go.dev/github.com/vmware-labs/reconciler-runtime/reconcilers#While) calls the reconciler so long as the condition is true, up to the maximum number of iterations (defaults to 100). The current iteration index can be retried with [`RetrieveIteration`](https://pkg.go.dev/github.com/vmware-labs/reconciler-runtime/reconcilers#RetrieveIteration).
+
+This reconciler must not be used to wait for an external to change, or for polling as this will block the reconciler queue. It to return with the result requesting to be requeued, or to watch the external state for changes that enqueue the reconcile request.
+
+**Example:**
+
+An While can be used to fan out. 
+
+```go
+func TenTimesReconciler() *reconcilers.SubReconciler[*buildv1alpha1.Function] {
+	return &reconcilers.While[*buildv1alpha1.Function]{
+		Condition: func(ctx context.Context, resource *buildv1alpha1.Function) bool {
+			return reconcilers.RetrieveIteration(ctx) < 10
+		}
+		Reconciler: reconcilers.SyncReconciler[*buildv1alpha1.Function]{
+			Sync: func(ctx context.Context, resource *buildv1alpha1.Function) error {
+				// called ten times
+				return nil
+			}
+		},
+	}
+}
+```
+
+#### TryCatch
+
+A [`TryCatch`](https://pkg.go.dev/github.com/vmware-labs/reconciler-runtime/reconcilers#TryCatch) is used to recover from errors returned by a reconciler. The `Catch` method is called with the result and error from the `Try` reconciler, giving it the option to either continue the existing results, or replace them with new results.
+
+The `Finally` reconciler is always called before returning, but does not alter the results unless it errors. The finally reconciler should avoid complex logic and be limited to cleaning up common state from the try reconciler.
+
+**Example:**
+
+An While can be used to fan out. 
+
+```go
+func IgnoreErrorsReconciler() *reconcilers.SubReconciler[*buildv1alpha1.Function] {
+	return &reconcilers.TryCatch[*buildv1alpha1.Function]{
+		Try: &reconcilers.SyncReconciler[*buildv1alpha1.Function]{
+			Sync: func(ctx context.Context, resource *buildv1alpha1.Function) error {
+				return fmt.Errorf("alway error?")
+			}
+		},
+		Catch: func(ctx context.Context, resource *buildv1alpha1.Function, result reconcile.Result, err error) (reconcile.Result,  error) {
+			// suppress error
+			return result, nil
+		},
+	}
+}
+```
+
+#### OverrideSetup
+
+An [`OverrideSetup`](https://pkg.go.dev/github.com/vmware-labs/reconciler-runtime/reconcilers#OverrideSetup) is used to suppress or replace the setup behavior for a reconciler.
+
+**Example:**
+
+OverrideSetup is useful when the default setup behavior for a reconciler is problematic in a particular context.
+
+```go
+func CustomSetupReconciler() *reconcilers.SubReconciler[*buildv1alpha1.Function] {
+	return &reconcilers.OverrideSetup[*buildv1alpha1.Function]{
+		Reconciler: &reconciler.SyncReconciler[*buildv1alpha1.Function]{
+			Setup: func(ctx context.Context, mgr Manager, bldr *Builder) error {
+				// not called
+				panic()
+			}
+			Sync: func(ctx context.Context, resource *buildv1alpha1.Function) error {
+				// called normally
+				return nil
+			}
+		},
+		Setup: func(ctx context.Context, mgr Manager, bldr *Builder) error {
+			// custom setup behavior, optional
+			return nil
+		},
+	}
+}
+```
 
 #### WithConfig
 

--- a/README.md
+++ b/README.md
@@ -480,9 +480,9 @@ func GatedReconciler() *reconcilers.SubReconciler[*buildv1alpha1.Function] {
 
 #### While
 
-A [`While`](https://pkg.go.dev/github.com/vmware-labs/reconciler-runtime/reconcilers#While) calls the reconciler so long as the condition is true, up to the maximum number of iterations (defaults to 100). The current iteration index can be retried with [`RetrieveIteration`](https://pkg.go.dev/github.com/vmware-labs/reconciler-runtime/reconcilers#RetrieveIteration).
+A [`While`](https://pkg.go.dev/github.com/vmware-labs/reconciler-runtime/reconcilers#While) calls the reconciler so long as the condition is true, up to the maximum number of iterations (defaults to 100). The current iteration index can be retrieved with [`RetrieveIteration`](https://pkg.go.dev/github.com/vmware-labs/reconciler-runtime/reconcilers#RetrieveIteration).
 
-This reconciler must not be used to wait for an external to change, or for polling as this will block the reconciler queue. It to return with the result requesting to be requeued, or to watch the external state for changes that enqueue the reconcile request.
+This reconciler must not be used to wait for external state to change, or for polling as this will block the reconciler queue. It is best to return with the result requesting to be requeued, or to watch the external state for changes that enqueue the reconcile request.
 
 **Example:**
 
@@ -508,18 +508,18 @@ func TenTimesReconciler() *reconcilers.SubReconciler[*buildv1alpha1.Function] {
 
 A [`TryCatch`](https://pkg.go.dev/github.com/vmware-labs/reconciler-runtime/reconcilers#TryCatch) is used to recover from errors returned by a reconciler. The `Catch` method is called with the result and error from the `Try` reconciler, giving it the option to either continue the existing results, or replace them with new results.
 
-The `Finally` reconciler is always called before returning, but does not alter the results unless it errors. The finally reconciler should avoid complex logic and be limited to cleaning up common state from the try reconciler.
+The `Finally` reconciler is always called before returning, but does not alter the existing result and err values unless it itself errors. The `Finally` reconciler should avoid complex logic and be limited to cleaning up common state from the `Try` reconciler.
 
 **Example:**
 
-An While can be used to fan out. 
+A `TryCatch` can be used to handle errors.
 
 ```go
 func IgnoreErrorsReconciler() *reconcilers.SubReconciler[*buildv1alpha1.Function] {
 	return &reconcilers.TryCatch[*buildv1alpha1.Function]{
 		Try: &reconcilers.SyncReconciler[*buildv1alpha1.Function]{
 			Sync: func(ctx context.Context, resource *buildv1alpha1.Function) error {
-				return fmt.Errorf("alway error?")
+				return fmt.Errorf("always error")
 			}
 		},
 		Catch: func(ctx context.Context, resource *buildv1alpha1.Function, result reconcile.Result, err error) (reconcile.Result,  error) {

--- a/reconcilers/flow.go
+++ b/reconcilers/flow.go
@@ -1,0 +1,471 @@
+/*
+Copyright 2023 VMware, Inc.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package reconcilers
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/go-logr/logr"
+	"k8s.io/utils/pointer"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	_ SubReconciler[client.Object] = (*IfThen[client.Object])(nil)
+	_ SubReconciler[client.Object] = (*While[client.Object])(nil)
+	_ SubReconciler[client.Object] = (*TryCatch[client.Object])(nil)
+	_ SubReconciler[client.Object] = (*OverrideSetup[client.Object])(nil)
+)
+
+// IfThen conditionally branches the reconcilers called for a request based on
+// a condition. When the If condition is true, Then is invoked; when false,
+// Else is invoked.
+type IfThen[Type client.Object] struct {
+	// Name used to identify this reconciler.  Defaults to `IfThen`.  Ideally
+	// unique, but not required to be so.
+	//
+	// +optional
+	Name string
+
+	// Setup performs initialization on the manager and builder this reconciler
+	// will run with. It's common to setup field indexes and watch resources.
+	//
+	// +optional
+	Setup func(ctx context.Context, mgr Manager, bldr *Builder) error
+
+	// If controls the flow of execution calling the Then reconciler when true,
+	// and the Else reconciler when false.
+	If func(ctx context.Context, resource Type) bool
+
+	// Then is called when If() returns true. Typically, Then is a Sequence of
+	// multiple SubReconcilers.
+	Then SubReconciler[Type]
+
+	// Else is called when If() returns false. Typically, Else is a Sequence of
+	// multiple SubReconcilers.
+	//
+	// +optional
+	Else SubReconciler[Type]
+
+	lazyInit sync.Once
+}
+
+func (r *IfThen[T]) init() {
+	r.lazyInit.Do(func() {
+		if r.Name == "" {
+			r.Name = "IfThen"
+		}
+	})
+}
+
+func (r *IfThen[T]) validate(ctx context.Context) error {
+	// require If
+	if r.If == nil {
+		return fmt.Errorf("IfThen %q must implement If", r.Name)
+	}
+
+	// require Then
+	if r.Then == nil {
+		return fmt.Errorf("IfThen %q must implement Then", r.Name)
+	}
+
+	return nil
+}
+
+func (r *IfThen[T]) SetupWithManager(ctx context.Context, mgr ctrl.Manager, bldr *builder.Builder) error {
+	r.init()
+
+	log := logr.FromContextOrDiscard(ctx).
+		WithName(r.Name)
+	ctx = logr.NewContext(ctx, log)
+
+	if err := r.validate(ctx); err != nil {
+		return err
+	}
+
+	if r.Setup != nil {
+		if err := r.Setup(ctx, mgr, bldr); err != nil {
+			return err
+		}
+	}
+	if err := r.Then.SetupWithManager(ctx, mgr, bldr); err != nil {
+		return err
+	}
+	if r.Else != nil {
+		if err := r.Else.SetupWithManager(ctx, mgr, bldr); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *IfThen[T]) Reconcile(ctx context.Context, resource T) (Result, error) {
+	r.init()
+
+	log := logr.FromContextOrDiscard(ctx).
+		WithName(r.Name)
+	ctx = logr.NewContext(ctx, log)
+
+	if r.If(ctx, resource) {
+		return r.Then.Reconcile(ctx, resource)
+	} else if r.Else != nil {
+		return r.Else.Reconcile(ctx, resource)
+	}
+
+	return Result{}, nil
+}
+
+// ErrMaxIterations indicates the maximum number of loop iterations was
+// exceeded.
+type ErrMaxIterations struct {
+	Iterations int
+}
+
+func (err *ErrMaxIterations) Error() string {
+	return fmt.Sprintf("exceeded max iterations: %d", err.Iterations)
+}
+
+const iterationStashKey StashKey = "reconciler-runtime:iteration"
+
+func stashIteration(ctx context.Context, i int) context.Context {
+	return context.WithValue(ctx, iterationStashKey, i)
+}
+
+// RetrieveIteration returns the iteration index. If nested loops are executing
+// only the inner most iteration index is returned.
+//
+// -1 indicates the call is not within a loop.
+func RetrieveIteration(ctx context.Context) int {
+	v := ctx.Value(iterationStashKey)
+	if i, ok := v.(int); ok {
+		return i
+	}
+	return -1
+}
+
+// While the Condition is true call the Reconciler.
+//
+// While must not be used to block the reconciler awaiting a remote condition
+// change. Instead watch the remote condition for changes and enqueue a new
+// request to reconcile the resource.
+//
+// To avoid infinite loops, MaxIterations is defaulted to 100. Set
+// MaxIterations to 0 to disable. ErrMaxIterations is returned when the limit
+// is exceeded. The current iteration for the most local loop is available via
+// RetrieveIteration.
+type While[Type client.Object] struct {
+	// Name used to identify this reconciler.  Defaults to `While`.  Ideally
+	// unique, but not required to be so.
+	//
+	// +optional
+	Name string
+
+	// Setup performs initialization on the manager and builder this reconciler
+	// will run with. It's common to setup field indexes and watch resources.
+	//
+	// +optional
+	Setup func(ctx context.Context, mgr Manager, bldr *Builder) error
+
+	// Condition controls the execution flow calling the reconciler so long as
+	// the returned value remains true.
+	Condition func(ctx context.Context, resource Type) bool
+
+	// Reconciler is called so long as Condition() returns true. Typically,
+	// Reconciler is a Sequence of multiple SubReconcilers.
+	Reconciler SubReconciler[Type]
+
+	// MaxIterations guards against infinite loops by limiting the number of
+	// allowed iterations before returning an error. Defaults to 100, set to 0
+	// to disable.
+	MaxIterations *int
+
+	lazyInit sync.Once
+}
+
+func (r *While[T]) init() {
+	r.lazyInit.Do(func() {
+		if r.Name == "" {
+			r.Name = "While"
+		}
+		if r.MaxIterations == nil {
+			r.MaxIterations = pointer.Int(100)
+		}
+	})
+}
+
+func (r *While[T]) validate(ctx context.Context) error {
+	// require If
+	if r.Condition == nil {
+		return fmt.Errorf("While %q must implement Condition", r.Name)
+	}
+
+	// require Reconciler
+	if r.Reconciler == nil {
+		return fmt.Errorf("While %q must implement Reconciler", r.Name)
+	}
+
+	return nil
+}
+
+func (r *While[T]) SetupWithManager(ctx context.Context, mgr ctrl.Manager, bldr *builder.Builder) error {
+	r.init()
+
+	log := logr.FromContextOrDiscard(ctx).
+		WithName(r.Name)
+	ctx = logr.NewContext(ctx, log)
+
+	if err := r.validate(ctx); err != nil {
+		return err
+	}
+
+	if r.Setup != nil {
+		if err := r.Setup(ctx, mgr, bldr); err != nil {
+			return err
+		}
+	}
+	if err := r.Reconciler.SetupWithManager(ctx, mgr, bldr); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *While[T]) Reconcile(ctx context.Context, resource T) (Result, error) {
+	r.init()
+
+	log := logr.FromContextOrDiscard(ctx).
+		WithName(r.Name)
+	ctx = logr.NewContext(ctx, log)
+
+	aggregateResult := Result{}
+	for i := 0; true; i++ {
+		if *r.MaxIterations != 0 && i >= *r.MaxIterations {
+			return aggregateResult, &ErrMaxIterations{Iterations: i}
+		}
+
+		log := logr.FromContextOrDiscard(ctx).
+			WithName(fmt.Sprintf("%d", i))
+		ctx := logr.NewContext(ctx, log)
+		ctx = stashIteration(ctx, i)
+
+		if !r.Condition(ctx, resource) {
+			break
+		}
+
+		result, err := r.Reconciler.Reconcile(ctx, resource)
+		aggregateResult = AggregateResults(aggregateResult, result)
+		if err != nil {
+			return aggregateResult, err
+		}
+	}
+
+	return aggregateResult, nil
+}
+
+// TryCatch facilitates recovery from errors encountered within the Try
+// reconciler. The results of the Try reconciler are passed to the Catch
+// handler which can suppress, modify or continue the error. The Finally
+// reconciler is always called before returning, but cannot prevent an
+// error from being returned.
+//
+// The semantics mimic the try-catch-finally behavior from C-style languages:
+//   - Try, Catch, Finally are called in order for each request.
+//   - Catch can fully redefine the results from Try.
+//   - if Catch is not defined, the Try results are implicitly propagated.
+//   - if the results are in error before Finally is called, the final results
+//     will be in error.
+//   - an error returned from Finally will preempt an existing error.
+//   - the existing Result is aggregated with the Finally Result.
+//
+// Use of Finally should be limited to common clean up logic that applies
+// equally to normal and error conditions. Further flow control within Finally
+// is discouraged as new errors can mask errors returned from Catch.
+type TryCatch[Type client.Object] struct {
+	// Name used to identify this reconciler.  Defaults to `TryCatch`.  Ideally
+	// unique, but not required to be so.
+	//
+	// +optional
+	Name string
+
+	// Setup performs initialization on the manager and builder this reconciler
+	// will run with. It's common to setup field indexes and watch resources.
+	//
+	// +optional
+	Setup func(ctx context.Context, mgr Manager, bldr *Builder) error
+
+	// Try is a reconciler that may return an error that needs to be handled.
+	// Typically, Try is a Sequence of multiple SubReconcilers.
+	Try SubReconciler[Type]
+
+	// Catch is called with the results from Try(). New results can be returned
+	// suppressing the original results.
+	//
+	// +optional
+	Catch func(ctx context.Context, resource Type, result Result, err error) (Result, error)
+
+	// Finally is always called before returning. An error from Finally will
+	// always be returned. If Finally does not return an error, the error state
+	// before Finally was called will be returned along with the result
+	// aggregated.
+	//
+	// Typically, Finally is a Sequence of multiple SubReconcilers.
+	//
+	// +optional
+	Finally SubReconciler[Type]
+
+	lazyInit sync.Once
+}
+
+func (r *TryCatch[T]) init() {
+	r.lazyInit.Do(func() {
+		if r.Name == "" {
+			r.Name = "TryCatch"
+		}
+	})
+}
+
+func (r *TryCatch[T]) validate(ctx context.Context) error {
+	// require Try
+	if r.Try == nil {
+		return fmt.Errorf("TryCatch %q must implement Try", r.Name)
+	}
+
+	return nil
+}
+
+func (r *TryCatch[T]) SetupWithManager(ctx context.Context, mgr ctrl.Manager, bldr *builder.Builder) error {
+	r.init()
+
+	log := logr.FromContextOrDiscard(ctx).
+		WithName(r.Name)
+	ctx = logr.NewContext(ctx, log)
+
+	if err := r.validate(ctx); err != nil {
+		return err
+	}
+
+	if r.Setup != nil {
+		if err := r.Setup(ctx, mgr, bldr); err != nil {
+			return err
+		}
+	}
+	if err := r.Try.SetupWithManager(ctx, mgr, bldr); err != nil {
+		return err
+	}
+	if r.Finally != nil {
+		if err := r.Finally.SetupWithManager(ctx, mgr, bldr); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *TryCatch[T]) Reconcile(ctx context.Context, resource T) (Result, error) {
+	r.init()
+
+	log := logr.FromContextOrDiscard(ctx).
+		WithName(r.Name)
+	ctx = logr.NewContext(ctx, log)
+
+	result, err := r.Try.Reconcile(ctx, resource)
+	if r.Catch != nil {
+		result, err = r.Catch(ctx, resource, result, err)
+	}
+	if r.Finally != nil {
+		fresult, ferr := r.Finally.Reconcile(ctx, resource)
+		if ferr != nil {
+			// an error from Finally overrides the existing err
+			return AggregateResults(result, fresult), ferr
+		}
+		result = AggregateResults(result, fresult)
+	}
+
+	return result, err
+}
+
+// OverrideSetup suppresses the SetupWithManager on the nested Reconciler in
+// favor of the local Setup method.
+type OverrideSetup[Type client.Object] struct {
+	// Name used to identify this reconciler.  Defaults to `SkipSetup`. Ideally
+	// unique, but not required to be so.
+	//
+	// +optional
+	Name string
+
+	// Setup allows for custom initialization on the manager and builder this
+	// reconciler will run with. Since the SetupWithManager method will not be
+	// called on Reconciler, this method can be used to provide an alternative
+	// setup. It's common to setup field indexes and watch resources.
+	//
+	// +optional
+	Setup func(ctx context.Context, mgr Manager, bldr *Builder) error
+
+	// Reconciler is called for each reconciler request with the reconciled
+	// resource being reconciled. SetupWithManager will not be called on this
+	// reconciler. Typically a Sequence is used to compose multiple
+	// SubReconcilers.
+	//
+	// +optional
+	Reconciler SubReconciler[Type]
+
+	lazyInit sync.Once
+}
+
+func (r *OverrideSetup[T]) init() {
+	r.lazyInit.Do(func() {
+		if r.Name == "" {
+			r.Name = "SkipSetup"
+		}
+	})
+}
+
+func (r *OverrideSetup[T]) validate(ctx context.Context) error {
+	if r.Setup == nil && r.Reconciler == nil {
+		return fmt.Errorf("OverrideSetup %q must implement at least one of Setup or Reconciler", r.Name)
+	}
+
+	return nil
+}
+
+func (r *OverrideSetup[T]) SetupWithManager(ctx context.Context, mgr ctrl.Manager, bldr *builder.Builder) error {
+	r.init()
+
+	log := logr.FromContextOrDiscard(ctx).
+		WithName(r.Name)
+	ctx = logr.NewContext(ctx, log)
+
+	if err := r.validate(ctx); err != nil {
+		return err
+	}
+
+	if r.Setup != nil {
+		if err := r.Setup(ctx, mgr, bldr); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *OverrideSetup[T]) Reconcile(ctx context.Context, resource T) (Result, error) {
+	r.init()
+
+	log := logr.FromContextOrDiscard(ctx).
+		WithName(r.Name)
+	ctx = logr.NewContext(ctx, log)
+
+	if r.Reconciler == nil {
+		return Result{}, nil
+	}
+
+	return r.Reconciler.Reconcile(ctx, resource)
+}

--- a/reconcilers/flow_test.go
+++ b/reconcilers/flow_test.go
@@ -1,0 +1,497 @@
+/*
+Copyright 2023 VMware, Inc.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package reconcilers_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	diemetav1 "dies.dev/apis/meta/v1"
+	"github.com/vmware-labs/reconciler-runtime/internal/resources"
+	"github.com/vmware-labs/reconciler-runtime/internal/resources/dies"
+	"github.com/vmware-labs/reconciler-runtime/reconcilers"
+	rtesting "github.com/vmware-labs/reconciler-runtime/testing"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestIfThen(t *testing.T) {
+	testNamespace := "test-namespace"
+	testName := "test-resource"
+
+	scheme := runtime.NewScheme()
+	_ = resources.AddToScheme(scheme)
+
+	resource := dies.TestResourceBlank.
+		MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+			d.Namespace(testNamespace)
+			d.Name(testName)
+		}).
+		SpecDie(func(d *dies.TestResourceSpecDie) {
+			d.Fields(map[string]string{})
+		})
+
+	rts := rtesting.SubReconcilerTests[*resources.TestResource]{
+		"then": {
+			Metadata: map[string]interface{}{
+				"Condition": true,
+			},
+			Resource: resource.DieReleasePtr(),
+			ExpectResource: resource.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("then", "called")
+				}).
+				DieReleasePtr(),
+			ExpectedResult: reconcile.Result{RequeueAfter: 1},
+		},
+		"then error": {
+			Metadata: map[string]interface{}{
+				"Condition": true,
+				"ThenError": fmt.Errorf("then error"),
+				"ElseError": fmt.Errorf("else error"),
+			},
+			Resource: resource.DieReleasePtr(),
+			ExpectResource: resource.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("then", "called")
+				}).
+				DieReleasePtr(),
+			ShouldErr: true,
+			Verify: func(t *testing.T, result reconcilers.Result, err error) {
+				if result != (reconcile.Result{RequeueAfter: 1}) {
+					t.Errorf("unexpected result: %v", result)
+				}
+				if err.Error() != "then error" {
+					t.Errorf("unexpected error: %s", err)
+				}
+			},
+		},
+		"else": {
+			Metadata: map[string]interface{}{
+				"Condition": false,
+			},
+			Resource: resource.DieReleasePtr(),
+			ExpectResource: resource.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("else", "called")
+				}).
+				DieReleasePtr(),
+			ExpectedResult: reconcile.Result{RequeueAfter: 2},
+		},
+		"else error": {
+			Metadata: map[string]interface{}{
+				"Condition": false,
+				"ThenError": fmt.Errorf("then error"),
+				"ElseError": fmt.Errorf("else error"),
+			},
+			Resource: resource.DieReleasePtr(),
+			ExpectResource: resource.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("else", "called")
+				}).
+				DieReleasePtr(),
+			ShouldErr: true,
+			Verify: func(t *testing.T, result reconcilers.Result, err error) {
+				if result != (reconcile.Result{RequeueAfter: 2}) {
+					t.Errorf("unexpected result: %v", result)
+				}
+				if err.Error() != "else error" {
+					t.Errorf("unexpected error: %s", err)
+				}
+			},
+		},
+	}
+
+	rts.Run(t, scheme, func(t *testing.T, rtc *rtesting.SubReconcilerTestCase[*resources.TestResource], c reconcilers.Config) reconcilers.SubReconciler[*resources.TestResource] {
+		return &reconcilers.IfThen[*resources.TestResource]{
+			If: func(ctx context.Context, resource *resources.TestResource) bool {
+				return rtc.Metadata["Condition"].(bool)
+			},
+			Then: &reconcilers.SyncReconciler[*resources.TestResource]{
+				SyncWithResult: func(ctx context.Context, resource *resources.TestResource) (reconcilers.Result, error) {
+					resource.Spec.Fields["then"] = "called"
+					var thenErr error
+					if err, ok := rtc.Metadata["ThenError"]; ok {
+						thenErr = err.(error)
+					}
+					return reconcilers.Result{RequeueAfter: 1}, thenErr
+				},
+			},
+			Else: &reconcilers.SyncReconciler[*resources.TestResource]{
+				SyncWithResult: func(ctx context.Context, resource *resources.TestResource) (reconcilers.Result, error) {
+					resource.Spec.Fields["else"] = "called"
+					var elseErr error
+					if err, ok := rtc.Metadata["ElseError"]; ok {
+						elseErr = err.(error)
+					}
+					return reconcilers.Result{RequeueAfter: 2}, elseErr
+				},
+			},
+		}
+	})
+}
+
+func TestWhile(t *testing.T) {
+	testNamespace := "test-namespace"
+	testName := "test-resource"
+
+	scheme := runtime.NewScheme()
+	_ = resources.AddToScheme(scheme)
+
+	resource := dies.TestResourceBlank.
+		MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+			d.Namespace(testNamespace)
+			d.Name(testName)
+		}).
+		SpecDie(func(d *dies.TestResourceSpecDie) {
+			d.Fields(map[string]string{})
+		})
+
+	rts := rtesting.SubReconcilerTests[*resources.TestResource]{
+		"return immediately": {
+			Metadata: map[string]interface{}{
+				"Iterations": 0,
+			},
+			Resource:       resource.DieReleasePtr(),
+			ExpectResource: resource.DieReleasePtr(),
+			ExpectedResult: reconcile.Result{RequeueAfter: 0},
+		},
+		"return after 10 iterations": {
+			Metadata: map[string]interface{}{
+				"Iterations": 10,
+			},
+			Resource: resource.DieReleasePtr(),
+			ExpectResource: resource.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("iterations", "10")
+				}).
+				DieReleasePtr(),
+			ExpectedResult: reconcile.Result{RequeueAfter: 990},
+		},
+		"halt after default max iterations": {
+			Metadata: map[string]interface{}{
+				"Iterations": 1000,
+			},
+			Resource: resource.DieReleasePtr(),
+			ExpectResource: resource.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("iterations", "100")
+				}).
+				DieReleasePtr(),
+			ShouldErr: true,
+			Verify: func(t *testing.T, result reconcilers.Result, err error) {
+				if result != (reconcile.Result{RequeueAfter: 900}) {
+					t.Errorf("unexpected result: %v", result)
+				}
+				if err.Error() != "exceeded max iterations: 100" {
+					t.Errorf("unexpected error: %s", err)
+				}
+			},
+		},
+		"return before custom max iterations": {
+			Metadata: map[string]interface{}{
+				"MaxIterations": 10,
+				"Iterations":    5,
+			},
+			Resource: resource.DieReleasePtr(),
+			ExpectResource: resource.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("iterations", "5")
+				}).
+				DieReleasePtr(),
+			ExpectedResult: reconcile.Result{RequeueAfter: 995},
+		},
+		"halt after custom max iterations": {
+			Metadata: map[string]interface{}{
+				"MaxIterations": 10,
+				"Iterations":    1000,
+			},
+			Resource: resource.DieReleasePtr(),
+			ExpectResource: resource.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("iterations", "10")
+				}).
+				DieReleasePtr(),
+			ShouldErr: true,
+			Verify: func(t *testing.T, result reconcilers.Result, err error) {
+				if result != (reconcile.Result{RequeueAfter: 990}) {
+					t.Errorf("unexpected result: %v", result)
+				}
+				if err.Error() != "exceeded max iterations: 10" {
+					t.Errorf("unexpected error: %s", err)
+				}
+			},
+		},
+	}
+
+	rts.Run(t, scheme, func(t *testing.T, rtc *rtesting.SubReconcilerTestCase[*resources.TestResource], c reconcilers.Config) reconcilers.SubReconciler[*resources.TestResource] {
+		var desiredIterations int
+		if i, ok := rtc.Metadata["Iterations"]; ok {
+			desiredIterations = i.(int)
+		}
+
+		r := &reconcilers.While[*resources.TestResource]{
+			Condition: func(ctx context.Context, resource *resources.TestResource) bool {
+				return desiredIterations != reconcilers.RetrieveIteration(ctx)
+			},
+			Reconciler: &reconcilers.SyncReconciler[*resources.TestResource]{
+				SyncWithResult: func(ctx context.Context, resource *resources.TestResource) (reconcile.Result, error) {
+					i := reconcilers.RetrieveIteration(ctx) + 1
+					resource.Spec.Fields["iterations"] = fmt.Sprintf("%d", i)
+					return reconcile.Result{RequeueAfter: time.Duration(1000 - i)}, nil
+				},
+			},
+		}
+		if i, ok := rtc.Metadata["MaxIterations"]; ok {
+			r.MaxIterations = pointer.Int(i.(int))
+		}
+
+		return r
+	})
+}
+
+func TestTryCatch(t *testing.T) {
+	testNamespace := "test-namespace"
+	testName := "test-resource"
+
+	scheme := runtime.NewScheme()
+	_ = resources.AddToScheme(scheme)
+
+	resource := dies.TestResourceBlank.
+		MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+			d.Namespace(testNamespace)
+			d.Name(testName)
+		}).
+		SpecDie(func(d *dies.TestResourceSpecDie) {
+			d.Fields(map[string]string{})
+		})
+
+	rts := rtesting.SubReconcilerTests[*resources.TestResource]{
+		"catch rethrow": {
+			Metadata: map[string]interface{}{
+				"TryError": fmt.Errorf("try"),
+				"Catch": func(ctx context.Context, resource *resources.TestResource, result reconcile.Result, err error) (reconcile.Result, error) {
+					resource.Spec.Fields["catch"] = "called"
+					return result, err
+				},
+			},
+			Resource: resource.DieReleasePtr(),
+			ExpectResource: resource.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("try", "called")
+					d.AddField("catch", "called")
+				}).
+				DieReleasePtr(),
+			ShouldErr: true,
+			Verify: func(t *testing.T, result reconcilers.Result, err error) {
+				if result != (reconcile.Result{RequeueAfter: 3}) {
+					t.Errorf("unexpected result: %v", result)
+				}
+				if err.Error() != "try" {
+					t.Errorf("unexpected error: %s", err)
+				}
+			},
+		},
+		"catch and suppress error": {
+			Metadata: map[string]interface{}{
+				"TryError": fmt.Errorf("try"),
+				"Catch": func(ctx context.Context, resource *resources.TestResource, result reconcile.Result, err error) (reconcile.Result, error) {
+					resource.Spec.Fields["catch"] = "called"
+					return result, nil
+				},
+			},
+			Resource: resource.DieReleasePtr(),
+			ExpectResource: resource.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("try", "called")
+					d.AddField("catch", "called")
+				}).
+				DieReleasePtr(),
+			ExpectedResult: reconcile.Result{RequeueAfter: 3},
+		},
+		"catch and inject error": {
+			Metadata: map[string]interface{}{
+				"Catch": func(ctx context.Context, resource *resources.TestResource, result reconcile.Result, err error) (reconcile.Result, error) {
+					resource.Spec.Fields["catch"] = "called"
+					return reconcile.Result{RequeueAfter: 2}, fmt.Errorf("catch")
+				},
+			},
+			Resource: resource.DieReleasePtr(),
+			ExpectResource: resource.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("try", "called")
+					d.AddField("catch", "called")
+				}).
+				DieReleasePtr(),
+			ShouldErr: true,
+			Verify: func(t *testing.T, result reconcilers.Result, err error) {
+				if result != (reconcile.Result{RequeueAfter: 2}) {
+					t.Errorf("unexpected result: %v", result)
+				}
+				if err.Error() != "catch" {
+					t.Errorf("unexpected error: %s", err)
+				}
+			},
+		},
+		"finally": {
+			Metadata: map[string]interface{}{
+				"Catch": func(ctx context.Context, resource *resources.TestResource, result reconcile.Result, err error) (reconcile.Result, error) {
+					resource.Spec.Fields["catch"] = "called"
+					return result, err
+				},
+				"Finally": &reconcilers.SyncReconciler[*resources.TestResource]{
+					SyncWithResult: func(ctx context.Context, resource *resources.TestResource) (reconcile.Result, error) {
+						resource.Spec.Fields["finally"] = "called"
+						return reconcile.Result{RequeueAfter: 1}, nil
+					},
+				},
+			},
+			Resource: resource.DieReleasePtr(),
+			ExpectResource: resource.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("try", "called")
+					d.AddField("catch", "called")
+					d.AddField("finally", "called")
+				}).
+				DieReleasePtr(),
+			ExpectedResult: reconcile.Result{RequeueAfter: 1},
+		},
+		"finally with try error": {
+			Metadata: map[string]interface{}{
+				"TryError": fmt.Errorf("try"),
+				"Catch": func(ctx context.Context, resource *resources.TestResource, result reconcile.Result, err error) (reconcile.Result, error) {
+					resource.Spec.Fields["catch"] = "called"
+					return result, err
+				},
+				"Finally": &reconcilers.SyncReconciler[*resources.TestResource]{
+					SyncWithResult: func(ctx context.Context, resource *resources.TestResource) (reconcile.Result, error) {
+						resource.Spec.Fields["finally"] = "called"
+						return reconcile.Result{RequeueAfter: 1}, nil
+					},
+				},
+			},
+			Resource: resource.DieReleasePtr(),
+			ExpectResource: resource.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("try", "called")
+					d.AddField("catch", "called")
+					d.AddField("finally", "called")
+				}).
+				DieReleasePtr(),
+			ShouldErr: true,
+			Verify: func(t *testing.T, result reconcilers.Result, err error) {
+				if result != (reconcile.Result{RequeueAfter: 1}) {
+					t.Errorf("unexpected result: %v", result)
+				}
+				if err.Error() != "try" {
+					t.Errorf("unexpected error: %s", err)
+				}
+			},
+		},
+		"finally error overrides try error": {
+			Metadata: map[string]interface{}{
+				"TryError": fmt.Errorf("try"),
+				"Catch": func(ctx context.Context, resource *resources.TestResource, result reconcile.Result, err error) (reconcile.Result, error) {
+					resource.Spec.Fields["catch"] = "called"
+					return result, err
+				},
+				"Finally": &reconcilers.SyncReconciler[*resources.TestResource]{
+					SyncWithResult: func(ctx context.Context, resource *resources.TestResource) (reconcile.Result, error) {
+						resource.Spec.Fields["finally"] = "called"
+						return reconcile.Result{RequeueAfter: 1}, fmt.Errorf("finally")
+					},
+				},
+			},
+			Resource: resource.DieReleasePtr(),
+			ExpectResource: resource.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("try", "called")
+					d.AddField("catch", "called")
+					d.AddField("finally", "called")
+				}).
+				DieReleasePtr(),
+			ShouldErr: true,
+			Verify: func(t *testing.T, result reconcilers.Result, err error) {
+				if result != (reconcile.Result{RequeueAfter: 1}) {
+					t.Errorf("unexpected result: %v", result)
+				}
+				if err.Error() != "finally" {
+					t.Errorf("unexpected error: %s", err)
+				}
+			},
+		},
+	}
+
+	rts.Run(t, scheme, func(t *testing.T, rtc *rtesting.SubReconcilerTestCase[*resources.TestResource], c reconcilers.Config) reconcilers.SubReconciler[*resources.TestResource] {
+		r := &reconcilers.TryCatch[*resources.TestResource]{
+			Try: &reconcilers.SyncReconciler[*resources.TestResource]{
+				SyncWithResult: func(ctx context.Context, resource *resources.TestResource) (reconcilers.Result, error) {
+					resource.Spec.Fields["try"] = "called"
+					var tryErr error
+					if err, ok := rtc.Metadata["TryError"]; ok {
+						tryErr = err.(error)
+					}
+					return reconcilers.Result{RequeueAfter: 3}, tryErr
+				},
+			},
+		}
+		if catch, ok := rtc.Metadata["Catch"]; ok {
+			r.Catch = catch.(func(context.Context, *resources.TestResource, reconcile.Result, error) (reconcile.Result, error))
+		}
+		if finally, ok := rtc.Metadata["Finally"]; ok {
+			r.Finally = finally.(reconcilers.SubReconciler[*resources.TestResource])
+		}
+		return r
+	})
+}
+
+func TestOverrideSetup(t *testing.T) {
+	testNamespace := "test-namespace"
+	testName := "test-resource"
+
+	scheme := runtime.NewScheme()
+	_ = resources.AddToScheme(scheme)
+
+	resource := dies.TestResourceBlank.
+		MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+			d.Namespace(testNamespace)
+			d.Name(testName)
+		}).
+		SpecDie(func(d *dies.TestResourceSpecDie) {
+			d.Fields(map[string]string{})
+		})
+
+	rts := rtesting.SubReconcilerTests[*resources.TestResource]{
+		"calls reconcile": {
+			Resource: resource.DieReleasePtr(),
+			ExpectResource: resource.
+				SpecDie(func(d *dies.TestResourceSpecDie) {
+					d.AddField("reconciler", "called")
+				}).
+				DieReleasePtr(),
+			ExpectedResult: reconcile.Result{Requeue: true},
+		},
+	}
+
+	rts.Run(t, scheme, func(t *testing.T, rtc *rtesting.SubReconcilerTestCase[*resources.TestResource], c reconcilers.Config) reconcilers.SubReconciler[*resources.TestResource] {
+		return &reconcilers.OverrideSetup[*resources.TestResource]{
+			Reconciler: &reconcilers.SyncReconciler[*resources.TestResource]{
+				Setup: func(ctx context.Context, mgr manager.Manager, bldr *builder.Builder) error {
+					return fmt.Errorf("setup")
+				},
+				SyncWithResult: func(ctx context.Context, resource *resources.TestResource) (reconcilers.Result, error) {
+					resource.Spec.Fields["reconciler"] = "called"
+					return reconcilers.Result{Requeue: true}, nil
+				},
+			},
+		}
+	})
+}


### PR DESCRIPTION
Spike of reconcilers that direct the flow of a reconcile request at runtime.

- `IfThen` - branch execution based on a boolean condition
- `While` - iterate over a reconciler while a condition is true
- `TryCatch` - recover from errors or rewrite the result
- `OverrideSetup` - suppress calls to the SetupWithManager method