### PR TITLE
Switch to testr package

### DIFF
--- a/testing/reconciler.go
+++ b/testing/reconciler.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	logrtesting "github.com/go-logr/logr/testing"
+	"github.com/go-logr/logr/testr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/vmware-labs/reconciler-runtime/reconcilers"
 	rtime "github.com/vmware-labs/reconciler-runtime/time"
@@ -144,7 +144,7 @@ func (tc *ReconcilerTestCase) Run(t *testing.T, scheme *runtime.Scheme, factory 
 		tc.Now = time.Now()
 	}
 	ctx = rtime.StashNow(ctx, tc.Now)
-	ctx = logr.NewContext(ctx, logrtesting.NewTestLogger(t))
+	ctx = logr.NewContext(ctx, testr.New(t))
 	if deadline, ok := t.Deadline(); ok {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithDeadline(ctx, deadline)

--- a/testing/subreconciler.go
+++ b/testing/subreconciler.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	logrtesting "github.com/go-logr/logr/testing"
+	"github.com/go-logr/logr/testr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/vmware-labs/reconciler-runtime/internal"
@@ -148,7 +148,7 @@ func (tc *SubReconcilerTestCase[T]) Run(t *testing.T, scheme *runtime.Scheme, fa
 		tc.Now = time.Now()
 	}
 	ctx = rtime.StashNow(ctx, tc.Now)
-	ctx = logr.NewContext(ctx, logrtesting.NewTestLogger(t))
+	ctx = logr.NewContext(ctx, testr.New(t))
 	if deadline, ok := t.Deadline(); ok {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithDeadline(ctx, deadline)

--- a/testing/webhook.go
+++ b/testing/webhook.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	logrtesting "github.com/go-logr/logr/testing"
+	"github.com/go-logr/logr/testr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/vmware-labs/reconciler-runtime/reconcilers"
 	rtime "github.com/vmware-labs/reconciler-runtime/time"
@@ -137,7 +137,7 @@ func (tc *AdmissionWebhookTestCase) Run(t *testing.T, scheme *runtime.Scheme, fa
 		tc.Now = time.Now()
 	}
 	ctx = rtime.StashNow(ctx, tc.Now)
-	ctx = logr.NewContext(ctx, logrtesting.NewTestLogger(t))
+	ctx = logr.NewContext(ctx, testr.New(t))
 	if deadline, ok := t.Deadline(); ok {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithDeadline(ctx, deadline)


### PR DESCRIPTION
The logr/testing package was deprecated in favor of the logr/testr package. There are no changes in functionality as the logr/testing package is implemented using the logr/testr package.