### PR TITLE
Allow ChildReconciler to reflect invalid api errors

### DIFF
--- a/reconcilers/childset.go
+++ b/reconcilers/childset.go
@@ -89,6 +89,7 @@ type ChildSetReconciler[Type, ChildType client.Object, ChildListType client.Obje
 	// ReflectChildrenStatusOnParent updates the reconciled resource's status with values from the
 	// child reconciliations. Select types of errors are captured, including:
 	//   - apierrs.IsAlreadyExists
+	//   - apierrs.IsInvalid
 	//
 	// Most errors are returned directly, skipping this method. The set of handled error types
 	// may grow, implementations should be defensive rather than assuming the error type.


### PR DESCRIPTION
API errors with an "invalid" response from the server are now passed to ReflectChildStatusOnParent. They can be detected with:

    apierrs.IsInvalid(err)