### PR TITLE
Allow errors to be quiet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1076,8 +1076,11 @@ reconciler-runtime is rapidly evolving. While we strive for API compatability be
 
 ### Current Deprecations
 
-- status `InitializeConditions()` is deprecated in favor of `InitializeConditions(context.Context)`. Support may be removed in a future release, users are encouraged to migrate.
-- `ConditionSet#Manage` is deprecated in favor of `ConditionSet#ManageWithContext`. Support may be removed in a future release, users are encuraged to migrate.
+Backwards support may be removed in a future release, users are encouraged to migrate.
+
+- status `InitializeConditions()` is deprecated in favor of `InitializeConditions(context.Context)`.
+- `ConditionSet#Manage` is deprecated in favor of `ConditionSet#ManageWithContext`.
+- `HaltSubReconcilers` is deprecated in favor of `ErrHaltSubReconcilers`.
 
 ## Contributing
 

--- a/reconcilers/aggregate.go
+++ b/reconcilers/aggregate.go
@@ -62,7 +62,7 @@ type AggregateReconciler[Type client.Object] struct {
 	// Reconciler is called for each reconciler request with the resource being reconciled.
 	// Typically, Reconciler is a Sequence of multiple SubReconcilers.
 	//
-	// When HaltSubReconcilers is returned as an error, execution continues as if no error was
+	// When ErrHaltSubReconcilers is returned as an error, execution continues as if no error was
 	// returned.
 	//
 	// +optional
@@ -227,7 +227,9 @@ func (r *AggregateReconciler[T]) Reconcile(ctx context.Context, req Request) (Re
 			resource.SetNamespace(r.Request.Namespace)
 			resource.SetName(r.Request.Name)
 		} else {
-			log.Error(err, "unable to fetch resource")
+			if !errors.Is(err, ErrQuiet) {
+				log.Error(err, "unable to fetch resource")
+			}
 			return Result{}, err
 		}
 	}
@@ -238,7 +240,7 @@ func (r *AggregateReconciler[T]) Reconcile(ctx context.Context, req Request) (Re
 	}
 
 	result, err := r.Reconciler.Reconcile(ctx, resource)
-	if err != nil && !errors.Is(err, HaltSubReconcilers) {
+	if err != nil && !errors.Is(err, ErrHaltSubReconcilers) {
 		return result, err
 	}
 

--- a/reconcilers/aggregate_test.go
+++ b/reconcilers/aggregate_test.go
@@ -342,7 +342,7 @@ func TestAggregateReconciler(t *testing.T) {
 					r.Reconciler = reconcilers.Sequence[*corev1.ConfigMap]{
 						&reconcilers.SyncReconciler[*corev1.ConfigMap]{
 							Sync: func(ctx context.Context, resource *corev1.ConfigMap) error {
-								return reconcilers.HaltSubReconcilers
+								return reconcilers.ErrHaltSubReconcilers
 							},
 						},
 						&reconcilers.SyncReconciler[*corev1.ConfigMap]{
@@ -371,7 +371,7 @@ func TestAggregateReconciler(t *testing.T) {
 					r.Reconciler = reconcilers.Sequence[*corev1.ConfigMap]{
 						&reconcilers.SyncReconciler[*corev1.ConfigMap]{
 							SyncWithResult: func(ctx context.Context, resource *corev1.ConfigMap) (reconcilers.Result, error) {
-								return reconcilers.Result{Requeue: true}, reconcilers.HaltSubReconcilers
+								return reconcilers.Result{Requeue: true}, reconcilers.ErrHaltSubReconcilers
 							},
 						},
 						&reconcilers.SyncReconciler[*corev1.ConfigMap]{

--- a/reconcilers/resource_test.go
+++ b/reconcilers/resource_test.go
@@ -596,7 +596,7 @@ func TestResourceReconciler_Duck(t *testing.T) {
 								resource.Status.Fields = map[string]string{
 									"want": "this to run",
 								}
-								return reconcilers.HaltSubReconcilers
+								return reconcilers.ErrHaltSubReconcilers
 							},
 						},
 						&reconcilers.SyncReconciler[*resources.TestDuck]{
@@ -642,7 +642,7 @@ func TestResourceReconciler_Duck(t *testing.T) {
 								resource.Status.Fields = map[string]string{
 									"want": "this to run",
 								}
-								return reconcilers.Result{Requeue: true}, reconcilers.HaltSubReconcilers
+								return reconcilers.Result{Requeue: true}, reconcilers.ErrHaltSubReconcilers
 							},
 						},
 						&reconcilers.SyncReconciler[*resources.TestDuck]{
@@ -1104,7 +1104,7 @@ func TestResourceReconciler(t *testing.T) {
 								resource.Status.Fields = map[string]string{
 									"want": "this to run",
 								}
-								return reconcilers.Result{Requeue: true}, reconcilers.HaltSubReconcilers
+								return reconcilers.Result{Requeue: true}, reconcilers.ErrHaltSubReconcilers
 							},
 						},
 						&reconcilers.SyncReconciler[*resources.TestResource]{

--- a/reconcilers/sequence_test.go
+++ b/reconcilers/sequence_test.go
@@ -66,7 +66,7 @@ func TestSequence(t *testing.T) {
 							},
 						}, &reconcilers.SyncReconciler[*resources.TestResource]{
 							SyncWithResult: func(ctx context.Context, resource *resources.TestResource) (reconcilers.Result, error) {
-								return reconcilers.Result{RequeueAfter: 2 * time.Minute}, reconcilers.HaltSubReconcilers
+								return reconcilers.Result{RequeueAfter: 2 * time.Minute}, reconcilers.ErrHaltSubReconcilers
 							},
 						},
 					}

--- a/reconcilers/sync.go
+++ b/reconcilers/sync.go
@@ -7,6 +7,7 @@ package reconcilers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/go-logr/logr"
@@ -118,7 +119,9 @@ func (r *SyncReconciler[T]) Reconcile(ctx context.Context, resource T) (Result, 
 		syncResult, err := r.sync(ctx, resource)
 		result = AggregateResults(result, syncResult)
 		if err != nil {
-			log.Error(err, "unable to sync")
+			if !errors.Is(err, ErrQuiet) {
+				log.Error(err, "unable to sync")
+			}
 			return result, err
 		}
 	}
@@ -127,7 +130,9 @@ func (r *SyncReconciler[T]) Reconcile(ctx context.Context, resource T) (Result, 
 		finalizeResult, err := r.finalize(ctx, resource)
 		result = AggregateResults(result, finalizeResult)
 		if err != nil {
-			log.Error(err, "unable to finalize")
+			if !errors.Is(err, ErrQuiet) {
+				log.Error(err, "unable to finalize")
+			}
 			return result, err
 		}
 	}

--- a/reconcilers/sync_test.go
+++ b/reconcilers/sync_test.go
@@ -62,7 +62,7 @@ func TestSyncReconciler(t *testing.T) {
 				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler[*resources.TestResource] {
 					return &reconcilers.SyncReconciler[*resources.TestResource]{
 						SyncWithResult: func(ctx context.Context, resource *resources.TestResource) (reconcilers.Result, error) {
-							return reconcilers.Result{Requeue: true}, reconcilers.HaltSubReconcilers
+							return reconcilers.Result{Requeue: true}, reconcilers.ErrHaltSubReconcilers
 						},
 					}
 				},
@@ -148,7 +148,7 @@ func TestSyncReconciler(t *testing.T) {
 							return reconcilers.Result{RequeueAfter: 2 * time.Hour}, nil
 						},
 						FinalizeWithResult: func(ctx context.Context, resource *resources.TestResource) (reconcilers.Result, error) {
-							return reconcilers.Result{RequeueAfter: 3 * time.Hour}, reconcilers.HaltSubReconcilers
+							return reconcilers.Result{RequeueAfter: 3 * time.Hour}, reconcilers.ErrHaltSubReconcilers
 						},
 					}
 				},

--- a/reconcilers/webhook.go
+++ b/reconcilers/webhook.go
@@ -8,6 +8,7 @@ package reconcilers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"sync"
@@ -139,7 +140,9 @@ func (r *AdmissionWebhookAdapter[T]) Handle(ctx context.Context, req admission.R
 	})
 
 	if err := r.reconcile(ctx, req, resp); err != nil {
-		log.Error(err, "reconcile error")
+		if !errors.Is(err, ErrQuiet) {
+			log.Error(err, "reconcile error")
+		}
 		resp.Allowed = false
 		if resp.Result == nil {
 			resp.Result = &metav1.Status{


### PR DESCRIPTION
ErrQuiet errors are not logged within reconciler-runtime and do not trigger events to be recorded. This behavior is conventional rather than technical. An implementor may choose to ignore these conventions when it fits their purpose. Quite is not silent.

Also redefines ErrHaltSubReconcilers to wrap ErrQuiet. HaltSubReconcilers is deprecated in favor of ErrHaltSubReconcilers.