### PR TITLE
Capture resourceType GVK in logs for duck types

### DIFF
--- a/reconcilers/aggregate.go
+++ b/reconcilers/aggregate.go
@@ -140,7 +140,7 @@ func (r *AggregateReconciler[T]) SetupWithManagerYieldingController(ctx context.
 	log := logr.FromContextOrDiscard(ctx).
 		WithName(r.Name).
 		WithValues(
-			"resourceType", gvk(r.Type, r.Config.Scheme()),
+			"resourceType", gvk(r.Config, r.Type),
 			"request", r.Request,
 		)
 	ctx = logr.NewContext(ctx, log)
@@ -210,7 +210,7 @@ func (r *AggregateReconciler[T]) Reconcile(ctx context.Context, req Request) (Re
 
 	log := logr.FromContextOrDiscard(ctx).
 		WithName(r.Name).
-		WithValues("resourceType", gvk(r.Type, c.Scheme()))
+		WithValues("resourceType", gvk(c, r.Type))
 	ctx = logr.NewContext(ctx, log)
 
 	ctx = rtime.StashNow(ctx, time.Now())

--- a/reconcilers/cast.go
+++ b/reconcilers/cast.go
@@ -144,7 +144,7 @@ func (r *CastResource[T, CT]) cast(ctx context.Context, resource T) (context.Con
 	if kind := castResource.GetObjectKind(); kind.GroupVersionKind().Empty() {
 		// default the apiVersion/kind with the real value from the resource if not already defined
 		c := RetrieveConfigOrDie(ctx)
-		kind.SetGroupVersionKind(gvk(resource, c.Scheme()))
+		kind.SetGroupVersionKind(gvk(c, resource))
 	}
 	ctx = StashResourceType(ctx, castResource)
 	return ctx, castResource, nil

--- a/reconcilers/child.go
+++ b/reconcilers/child.go
@@ -190,7 +190,7 @@ func (r *ChildReconciler[T, CT, CLT]) SetupWithManager(ctx context.Context, mgr 
 
 	log := logr.FromContextOrDiscard(ctx).
 		WithName(r.Name).
-		WithValues("childType", gvk(r.ChildType, c.Scheme()))
+		WithValues("childType", gvk(c, r.ChildType))
 	ctx = logr.NewContext(ctx, log)
 
 	if err := r.validate(ctx); err != nil {
@@ -247,7 +247,7 @@ func (r *ChildReconciler[T, CT, CLT]) Reconcile(ctx context.Context, resource T)
 
 	log := logr.FromContextOrDiscard(ctx).
 		WithName(r.Name).
-		WithValues("childType", gvk(r.ChildType, c.Scheme()))
+		WithValues("childType", gvk(c, r.ChildType))
 	ctx = logr.NewContext(ctx, log)
 
 	child, err := r.reconcile(ctx, resource)

--- a/reconcilers/childset.go
+++ b/reconcilers/childset.go
@@ -180,7 +180,7 @@ func (r *ChildSetReconciler[T, CT, CLT]) SetupWithManager(ctx context.Context, m
 
 	log := logr.FromContextOrDiscard(ctx).
 		WithName(r.Name).
-		WithValues("childType", gvk(r.ChildType, c.Scheme()))
+		WithValues("childType", gvk(c, r.ChildType))
 	ctx = logr.NewContext(ctx, log)
 
 	if err := r.validate(ctx); err != nil {

--- a/reconcilers/reconcilers.go
+++ b/reconcilers/reconcilers.go
@@ -159,12 +159,12 @@ func typeName(i interface{}) string {
 	return t.Name()
 }
 
-func gvk(obj client.Object, scheme *runtime.Scheme) schema.GroupVersionKind {
-	gvks, _, err := scheme.ObjectKinds(obj)
+func gvk(c client.Client, obj runtime.Object) schema.GroupVersionKind {
+	gvk, err := c.GroupVersionKindFor(obj)
 	if err != nil {
 		return schema.GroupVersionKind{}
 	}
-	return gvks[0]
+	return gvk
 }
 
 func namespaceName(obj client.Object) types.NamespacedName {

--- a/reconcilers/resource.go
+++ b/reconcilers/resource.go
@@ -99,7 +99,7 @@ func (r *ResourceReconciler[T]) SetupWithManagerYieldingController(ctx context.C
 
 	log := logr.FromContextOrDiscard(ctx).
 		WithName(r.Name).
-		WithValues("resourceType", gvk(r.Type, r.Config.Scheme()))
+		WithValues("resourceType", gvk(r.Config, r.Type))
 	ctx = logr.NewContext(ctx, log)
 
 	ctx = StashConfig(ctx, r.Config)
@@ -188,7 +188,7 @@ func (r *ResourceReconciler[T]) Reconcile(ctx context.Context, req Request) (Res
 
 	log := logr.FromContextOrDiscard(ctx).
 		WithName(r.Name).
-		WithValues("resourceType", gvk(r.Type, c.Scheme()))
+		WithValues("resourceType", gvk(c, r.Type))
 	ctx = logr.NewContext(ctx, log)
 
 	ctx = rtime.StashNow(ctx, time.Now())


### PR DESCRIPTION
Reconcilers using duck type will now include the correct resourceType metadata in logs. Previously it was an empty GVK.