### PR TITLE
Allow ChildReconciler to opt-in to dangerous children

### DIFF
--- a/reconcilers/childset.go
+++ b/reconcilers/childset.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 
 	"github.com/go-logr/logr"
+	"github.com/vmware-labs/reconciler-runtime/duck"
 	"github.com/vmware-labs/reconciler-runtime/internal"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -151,6 +152,16 @@ type ChildSetReconciler[Type, ChildType client.Object, ChildListType client.Obje
 	// +optional
 	Sanitize func(child ChildType) interface{}
 
+	// DangerouslyAllowDuckTypedChildren allows the ChildType to be a duck typed resource. This is
+	// dangerous because duck types typically represent a subset of the target resource and may
+	// cause data loss if the resource's server representation contains fields that do not exist on
+	// the duck typed object.
+	//
+	// Use of this setting should be limited to when the author is certain the duck type is able to
+	// represent the resource with full fidelity, or when data loss for unrepresented fields is
+	// acceptable.
+	DangerouslyAllowDuckTypedChildren bool
+
 	stamp          *ResourceManager[ChildType]
 	lazyInit       sync.Once
 	voidReconciler *ChildReconciler[Type, ChildType, ChildListType]
@@ -232,11 +243,14 @@ func (r *ChildSetReconciler[T, CT, CLT]) childReconcilerFor(desired CT, desiredE
 			}
 			return void || id == r.IdentifyChild(child)
 		},
-		Sanitize: r.Sanitize,
+		Sanitize:                          r.Sanitize,
+		DangerouslyAllowDuckTypedChildren: r.DangerouslyAllowDuckTypedChildren,
 	}
 }
 
 func (r *ChildSetReconciler[T, CT, CLT]) validate(ctx context.Context) error {
+	c := RetrieveConfigOrDie(ctx)
+
 	// default implicit values
 	if r.Finalizer != "" {
 		r.SkipOwnerReference = true
@@ -260,6 +274,11 @@ func (r *ChildSetReconciler[T, CT, CLT]) validate(ctx context.Context) error {
 	// require IdentifyChild
 	if r.IdentifyChild == nil {
 		return fmt.Errorf("ChildSetReconciler %q must implement IdentifyChild", r.Name)
+	}
+
+	// require DangerouslyAllowDuckTypedChildren for duck types
+	if !r.DangerouslyAllowDuckTypedChildren && duck.IsDuck(r.ChildType, c.Scheme()) {
+		return fmt.Errorf("ChildSetReconciler %q must enable DangerouslyAllowDuckTypedChildren to use a child duck type", r.Name)
 	}
 
 	return nil

--- a/reconcilers/config.go
+++ b/reconcilers/config.go
@@ -49,6 +49,21 @@ func (c Config) WithCluster(cluster cluster.Cluster) Config {
 	}
 }
 
+// WithDangerousDuckClientOperations returns a new Config with client Create and Update methods for
+// duck typed objects enabled.
+//
+// This is dangerous because duck types typically represent a subset of the target resource and may
+// cause data loss if the resource's server representation contains fields that do not exist on the
+// duck typed object.
+func (c Config) WithDangerousDuckClientOperations() Config {
+	return Config{
+		Client:    duck.NewDangerousDuckAwareClientWrapper(c.Client),
+		APIReader: c.APIReader,
+		Recorder:  c.Recorder,
+		Tracker:   c.Tracker,
+	}
+}
+
 // TrackAndGet tracks the resources for changes and returns the current value. The track is
 // registered even when the resource does not exists so that its creation can be tracked.
 //


### PR DESCRIPTION
Duck types represent a partial view of a resource. It is dangerous to perform operation that assume the client has the full resource when it only has a portion of the resource. Calling update in this case can result in data loss as fields that are not part of the duck type will be dropped on the server. Likewise, it is difficult to create a resource with a partial object as required/essential fields may not be available.

This change allows users to explicitly override these concerns and use the ChildReconciler and ChildSetReconciler to manage a child via a duck type.  This should only be done when the user is certain the duck typed object contains all fields represented on the resource.