### PR TITLE
Add custom cmp.Options when comparing k8s objects

### DIFF
--- a/reconcilers/resource.go
+++ b/reconcilers/resource.go
@@ -34,6 +34,8 @@ import (
 
 var (
 	_ reconcile.Reconciler = (*ResourceReconciler[client.Object])(nil)
+
+	CmpOptions = make([]cmp.Option, 0)
 )
 
 // ResourceReconciler is a controller-runtime reconciler that reconciles a given
@@ -233,7 +235,7 @@ func (r *ResourceReconciler[T]) Reconcile(ctx context.Context, req Request) (Res
 	if !equality.Semantic.DeepEqual(resourceStatus, originalResourceStatus) && resource.GetDeletionTimestamp() == nil {
 		if duck.IsDuck(resource, c.Scheme()) {
 			// patch status
-			log.Info("patching status", "diff", cmp.Diff(originalResourceStatus, resourceStatus))
+			log.Info("patching status", "diff", cmp.Diff(originalResourceStatus, resourceStatus, CmpOptions...))
 			if patchErr := c.Status().Patch(ctx, resource, client.MergeFrom(originalResource)); patchErr != nil {
 				if !errors.Is(patchErr, ErrQuiet) {
 					log.Error(patchErr, "unable to patch status")
@@ -246,7 +248,7 @@ func (r *ResourceReconciler[T]) Reconcile(ctx context.Context, req Request) (Res
 				"Patched status")
 		} else {
 			// update status
-			log.Info("updating status", "diff", cmp.Diff(originalResourceStatus, resourceStatus))
+			log.Info("updating status", "diff", cmp.Diff(originalResourceStatus, resourceStatus, CmpOptions...))
 			if updateErr := c.Status().Update(ctx, resource); updateErr != nil {
 				if !errors.Is(updateErr, ErrQuiet) {
 					log.Error(updateErr, "unable to update status")

--- a/reconcilers/resourcemanager.go
+++ b/reconcilers/resourcemanager.go
@@ -203,7 +203,7 @@ func (r *ResourceManager[T]) Manage(ctx context.Context, resource client.Object,
 		log.Info("resource is in sync, no update required")
 		return actual, nil
 	}
-	log.Info("updating resource", "diff", cmp.Diff(r.sanitize(actual), r.sanitize(current)))
+	log.Info("updating resource", "diff", cmp.Diff(r.sanitize(actual), r.sanitize(current), CmpOptions...))
 	if err := c.Update(ctx, current); err != nil {
 		if !errors.Is(err, ErrQuiet) {
 			log.Error(err, "unable to update resource", "resource", namespaceName(current))

--- a/testing/config.go
+++ b/testing/config.go
@@ -218,7 +218,7 @@ func (c *ExpectConfig) AssertClientPatchExpectations(t *testing.T) {
 		}
 		actual := NewPatchRef(c.client.PatchActions[i])
 
-		if diff := cmp.Diff(exp, actual); diff != "" {
+		if diff := cmp.Diff(exp, actual, CmpOptions...); diff != "" {
 			c.errorf(t, "ExpectPatches[%d] differs%s (%s, %s):\n%s", i, c.configNameMsg(), DiffRemovedColor.Sprint("-expected"), DiffAddedColor.Sprint("+actual"), ColorizeDiff(diff))
 		}
 	}
@@ -243,7 +243,7 @@ func (c *ExpectConfig) AssertClientDeleteExpectations(t *testing.T) {
 		}
 		actual := NewDeleteRef(c.client.DeleteActions[i])
 
-		if diff := cmp.Diff(exp, actual); diff != "" {
+		if diff := cmp.Diff(exp, actual, CmpOptions...); diff != "" {
 			c.errorf(t, "ExpectDeletes[%d] differs%s (%s, %s):\n%s", i, c.configNameMsg(), DiffRemovedColor.Sprint("-expected"), DiffAddedColor.Sprint("+actual"), ColorizeDiff(diff))
 		}
 	}
@@ -268,7 +268,7 @@ func (c *ExpectConfig) AssertClientDeleteCollectionExpectations(t *testing.T) {
 		}
 		actual := NewDeleteCollectionRef(c.client.DeleteCollectionActions[i])
 
-		if diff := cmp.Diff(exp, actual, NormalizeLabelSelector, NormalizeFieldSelector); diff != "" {
+		if diff := cmp.Diff(exp, actual, append(CmpOptions, NormalizeLabelSelector, NormalizeFieldSelector)...); diff != "" {
 			c.errorf(t, "ExpectDeleteCollections[%d] differs%s (%s, %s):\n%s", i, c.configNameMsg(), DiffRemovedColor.Sprint("-expected"), DiffAddedColor.Sprint("+actual"), ColorizeDiff(diff))
 		}
 	}
@@ -303,7 +303,7 @@ func (c *ExpectConfig) AssertClientStatusPatchExpectations(t *testing.T) {
 		}
 		actual := NewPatchRef(c.client.StatusPatchActions[i])
 
-		if diff := cmp.Diff(exp, actual); diff != "" {
+		if diff := cmp.Diff(exp, actual, CmpOptions...); diff != "" {
 			c.errorf(t, "ExpectStatusPatches[%d] differs%s (%s, %s):\n%s", i, c.configNameMsg(), DiffRemovedColor.Sprint("-expected"), DiffAddedColor.Sprint("+actual"), ColorizeDiff(diff))
 		}
 	}
@@ -328,7 +328,7 @@ func (c *ExpectConfig) AssertRecorderExpectations(t *testing.T) {
 			continue
 		}
 
-		if diff := cmp.Diff(exp, actualEvents[i]); diff != "" {
+		if diff := cmp.Diff(exp, actualEvents[i], CmpOptions...); diff != "" {
 			c.errorf(t, "ExpectEvents[%d] differs%s (%s, %s):\n%s", i, c.configNameMsg(), DiffRemovedColor.Sprint("-expected"), DiffAddedColor.Sprint("+actual"), ColorizeDiff(diff))
 		}
 	}
@@ -355,7 +355,7 @@ func (c *ExpectConfig) AssertTrackerExpectations(t *testing.T) {
 			continue
 		}
 
-		if diff := cmp.Diff(exp, actualTracks[i], NormalizeLabelSelector); diff != "" {
+		if diff := cmp.Diff(exp, actualTracks[i], append(CmpOptions, NormalizeLabelSelector)...); diff != "" {
 			c.errorf(t, "ExpectTracks[%d] differs%s (%s, %s):\n%s", i, c.configNameMsg(), DiffRemovedColor.Sprint("-expected"), DiffAddedColor.Sprint("+actual"), ColorizeDiff(diff))
 		}
 	}
@@ -379,7 +379,7 @@ func (c *ExpectConfig) compareActions(t *testing.T, actionName string, expectedA
 		}
 		actual := actualActions[i].GetObject()
 
-		if diff := cmp.Diff(exp.DeepCopyObject(), actual, diffOptions...); diff != "" {
+		if diff := cmp.Diff(exp.DeepCopyObject(), actual, append(CmpOptions, diffOptions...)...); diff != "" {
 			c.errorf(t, "Expect%ss[%d] differs%s (%s, %s):\n%s", actionName, i, c.configNameMsg(), DiffRemovedColor.Sprint("-expected"), DiffAddedColor.Sprint("+actual"), ColorizeDiff(diff))
 		}
 	}
@@ -441,6 +441,8 @@ var (
 		}
 		return pointer.String(s.String())
 	})
+
+	CmpOptions = make([]cmp.Option, 0)
 )
 
 type PatchRef struct {

--- a/testing/reconciler.go
+++ b/testing/reconciler.go
@@ -206,7 +206,7 @@ func (tc *ReconcilerTestCase) Run(t *testing.T, scheme *runtime.Scheme, factory 
 	}
 	if err == nil {
 		// result is only significant if there wasn't an error
-		if diff := cmp.Diff(normalizeResult(tc.ExpectedResult), normalizeResult(result)); diff != "" {
+		if diff := cmp.Diff(normalizeResult(tc.ExpectedResult), normalizeResult(result), CmpOptions...); diff != "" {
 			t.Errorf("ExpectedResult differs (%s, %s): %s", DiffRemovedColor.Sprint("-expected"), DiffAddedColor.Sprint("+actual"), ColorizeDiff(diff))
 		}
 	}

--- a/testing/subreconciler.go
+++ b/testing/subreconciler.go
@@ -164,7 +164,7 @@ func (tc *SubReconcilerTestCase[T]) Run(t *testing.T, scheme *runtime.Scheme, fa
 	// Set func for verifying stashed values
 	if tc.VerifyStashedValue == nil {
 		tc.VerifyStashedValue = func(t *testing.T, key reconcilers.StashKey, expected, actual interface{}) {
-			if diff := cmp.Diff(expected, actual, IgnoreLastTransitionTime, SafeDeployDiff, IgnoreTypeMeta, IgnoreCreationTimestamp, IgnoreResourceVersion, cmpopts.EquateEmpty()); diff != "" {
+			if diff := cmp.Diff(expected, actual, append(CmpOptions, IgnoreLastTransitionTime, SafeDeployDiff, IgnoreTypeMeta, IgnoreCreationTimestamp, IgnoreResourceVersion, cmpopts.EquateEmpty())...); diff != "" {
 				t.Errorf("ExpectStashedValues[%q] differs (%s, %s): %s", key, DiffRemovedColor.Sprint("-expected"), DiffAddedColor.Sprint("+actual"), ColorizeDiff(diff))
 			}
 		}
@@ -261,7 +261,7 @@ func (tc *SubReconcilerTestCase[T]) Run(t *testing.T, scheme *runtime.Scheme, fa
 	}
 	if err == nil {
 		// result is only significant if there wasn't an error
-		if diff := cmp.Diff(normalizeResult(tc.ExpectedResult), normalizeResult(result)); diff != "" {
+		if diff := cmp.Diff(normalizeResult(tc.ExpectedResult), normalizeResult(result), CmpOptions...); diff != "" {
 			t.Errorf("ExpectedResult differs (%s, %s): %s", DiffRemovedColor.Sprint("-expected"), DiffAddedColor.Sprint("+actual"), ColorizeDiff(diff))
 		}
 	}
@@ -279,7 +279,7 @@ func (tc *SubReconcilerTestCase[T]) Run(t *testing.T, scheme *runtime.Scheme, fa
 		// mirror defaulting of the resource
 		expectedResource.SetResourceVersion("999")
 	}
-	if diff := cmp.Diff(expectedResource, resource, IgnoreLastTransitionTime, SafeDeployDiff, IgnoreTypeMeta, cmpopts.EquateEmpty()); diff != "" {
+	if diff := cmp.Diff(expectedResource, resource, append(CmpOptions, IgnoreLastTransitionTime, SafeDeployDiff, IgnoreTypeMeta, cmpopts.EquateEmpty())...); diff != "" {
 		t.Errorf("ExpectResource differs (%s, %s): %s", DiffRemovedColor.Sprint("-expected"), DiffAddedColor.Sprint("+actual"), ColorizeDiff(diff))
 	}
 

--- a/testing/webhook.go
+++ b/testing/webhook.go
@@ -216,7 +216,7 @@ func (tc *AdmissionWebhookTestCase) Run(t *testing.T, scheme *runtime.Scheme, fa
 	}()
 
 	tc.ExpectedResponse.Complete(*tc.Request)
-	if diff := cmp.Diff(tc.ExpectedResponse, response); diff != "" {
+	if diff := cmp.Diff(tc.ExpectedResponse, response, CmpOptions...); diff != "" {
 		t.Errorf("ExpectedResponse differs (%s, %s): %s", DiffRemovedColor.Sprint("-expected"), DiffAddedColor.Sprint("+actual"), ColorizeDiff(diff))
 	}
 


### PR DESCRIPTION
This fix allows adding custom comparator options and is especially useful when non standard k8s objects are used and may require custom comparators.

Resolves #484 