### PR TITLE
List children exactly once for ChildSetReconciler

### DIFF
--- a/reconcilers/childset_test.go
+++ b/reconcilers/childset_test.go
@@ -167,6 +167,9 @@ func TestChildSetReconciler(t *testing.T) {
 				configMapBlueGiven.DieReleasePtr(),
 				configMapGreenGiven.DieReleasePtr(),
 			},
+			WithReactors: []rtesting.ReactionFunc{
+				rtesting.CalledAtMostTimes("list", "ConfigMapList", 1),
+			},
 			Metadata: map[string]interface{}{
 				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler[*resources.TestResource] {
 					r := defaultChildSetReconciler(c)

--- a/testing/client.go
+++ b/testing/client.go
@@ -460,6 +460,21 @@ func InduceFailure(verb, kind string, o ...InduceFailureOpts) ReactionFunc {
 	}
 }
 
+// CalledAtMostTimes error if the client is called more than the max number of times for a verb and kind
+func CalledAtMostTimes(verb, kind string, maxCalls int) ReactionFunc {
+	callCount := 0
+	return func(action Action) (handled bool, ret runtime.Object, err error) {
+		if !action.Matches("list", "ConfigMapList") {
+			return false, nil, nil
+		}
+		callCount++
+		if callCount <= maxCalls {
+			return false, nil, nil
+		}
+		return true, nil, fmt.Errorf("%s %s called %d times, expected %d call(s)", verb, kind, callCount, maxCalls)
+	}
+}
+
 type namedAction interface {
 	Action
 	GetName() string


### PR DESCRIPTION
Previously, the ChildSetReconciler would list children once for the set and again for each child being reconciled. At best this was inefficient, at worst it introduced subtile issues when the content of the listing changed over the course of the reconcile.

Now the content of the list from the ChildSetReconciler is reused by each child that is reconciled.

Resolves #481 